### PR TITLE
Add services file to nail client builder to jersey

### DIFF
--- a/documents4j-client/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/documents4j-client/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.JerseyClientBuilder


### PR DESCRIPTION
This forces the use of `org.glassfish.jersey.client.JerseyClientBuilder` to build the client.

If the documents4j-client is used as dependency in another project and there are other libraries setting `javax.ws.rs.client.ClientBuilder` (e.g. RestEasy), this client will be used which is causing the documents4j-client to fail.