### PR TITLE
Remove null check pasted incorrectly

### DIFF
--- a/documents4j-server-standalone/src/main/java/com/documents4j/builder/ConverterServerBuilder.java
+++ b/documents4j-server-standalone/src/main/java/com/documents4j/builder/ConverterServerBuilder.java
@@ -225,7 +225,6 @@ public class ConverterServerBuilder {
      * @return This builder.
      */
     public ConverterServerBuilder serviceMode(boolean serviceMode) {
-        checkNotNull(sslContext);
         this.serviceMode = serviceMode;
         return this;
     }


### PR DESCRIPTION
In current 1.1.0 the server can not be started with `-M` and without `-ssl`, there seem to be a precondition (null check) copied and pasted from the method before causing this bug.