### PR TITLE
Separate maven profile extras into three different profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ mvn package -Pms-office
  
 When you are testing native converters such as the `MicrosoftWordBridge` or the `MicrosoftExcelBridge`, do not forget to keep an eye on your task manager. Consider an alternative to the default task manager such as [Process Explorer](http://technet.microsoft.com/en-us/sysinternals/bb896653.aspx) for debugging purposes. For monitoring network connections, I recommend [TCPView](http://technet.microsoft.com/de-de/sysinternals/bb897437.aspx). 
 
-Several time consuming operations such as building source code and javadoc artifacts as well as building the shaded jar for the standalone server are only executed when the corresponding profile `extras` is active.
+Several time consuming operations such as building source code and javadoc artifacts as well as building the shaded jar for the standalone server are only executed when the corresponding Maven profiles `shaded-jar`, `source` or `javadoc` are active.
 
 [![Build Status](https://travis-ci.org/documents4j/documents4j.svg)](https://travis-ci.org/documents4j/documents4j)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.documents4j/documents4j-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.documents4j/documents4j)

--- a/documents4j-client-standalone/pom.xml
+++ b/documents4j-client-standalone/pom.xml
@@ -48,7 +48,7 @@
 
     <profiles>
         <profile>
-            <id>extras</id>
+            <id>shaded-jar</id>
             <build>
                 <plugins>
                     <!-- Shade plugin: Allow all dependencies to be packed into a single jar file -->

--- a/documents4j-server-standalone/pom.xml
+++ b/documents4j-server-standalone/pom.xml
@@ -96,7 +96,7 @@
 
     <profiles>
         <profile>
-            <id>extras</id>
+            <id>shaded-jar</id>
             <build>
                 <plugins>
                     <!-- Shade plugin: Allow all dependencies to be packed into a single jar file -->

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
      Profile summary:
       (1) ms-office: Runs tests that require MS Word and MS Excel installed on MS Windows.
-      (2) extras: Creates additional artifacts, including a shaded jar for the standalone conversion server and standalone client
+      (2) shaded-jar: Build a shaded jar for the standalone conversion server and standalone client
       (3) javadoc: build javadoc
       (4) source: build source jar
       (5) checks: Perform additional source code checks (activated by default).
@@ -311,7 +311,7 @@
                 <version>${version.maven.release-plugin}</version>
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>extras</releaseProfiles>
+                    <releaseProfiles>shaded-jar,javadoc,source</releaseProfiles>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <tagNameFormat>documents4j-@{project.version}</tagNameFormat>
                 </configuration>
@@ -362,7 +362,7 @@
                     <version>${version.maven.release-plugin}</version>
                     <configuration>
                         <useReleaseProfile>false</useReleaseProfile>
-                        <releaseProfiles>extras</releaseProfiles>
+                        <releaseProfiles>shaded-jar,javadoc,source</releaseProfiles>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                     </configuration>
                 </plugin>
@@ -372,7 +372,7 @@
 
     <profiles>
         <profile>
-            <id>extras</id>
+            <id>source</id>
             <build>
                 <plugins>
                     <!-- Create source artifacts -->
@@ -389,7 +389,14 @@
                             </execution>
                         </executions>
                     </plugin>
-                    
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>javadoc</id>
+            <build>
+                <plugins>
                     <!-- Create javadoc artifacts -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
With the profile extras it was not possible to build the shaded-jar artefacts without building
the source and the javadoc artefact, this means it was not able to create the standalone jars
on your local system if there where e.g. errors in your javadoc, or if you did not have `pgp(.exe)`
installed to sign the source artefacts.

Now all three profiles are still selected as release profiles, but the standalone jars can
be built independently from the other profiles.