### PR TITLE
Ability to pass the script local converter should use

### DIFF
--- a/documents4j-api/src/main/java/com/documents4j/api/IConverter.java
+++ b/documents4j-api/src/main/java/com/documents4j/api/IConverter.java
@@ -71,6 +71,55 @@ public interface IConverter {
      * @return The current conversion specification.
      */
     IConversionJobWithSourceUnspecified convert(IFileSource source);
+        
+    /**
+     * Converts a source that is represented as a {@link InputStream}. The input stream will
+     * be closed after the conversion is complete.
+     *
+     * @param source The conversion input as an input stream.
+     * @param script The conversion script as an input stream.
+     * @return The current conversion specification.
+     */
+    IConversionJobWithSourceUnspecified convert(InputStream source, InputStream script);
+
+    /**
+     * Converts a source that is represented as a {@link InputStream}.
+     *
+     * @param source The conversion input as an input stream.
+     * @param script The conversion script as an input stream.
+     * @param close  Whether the {@link InputStream} is closed after the conversion terminates.
+     * @return The current conversion specification.
+     */
+    IConversionJobWithSourceUnspecified convert(InputStream source, InputStream script, boolean close);
+
+    /**
+     * Invokes a callback for the dynamic generation of a input stream source which is additionally
+     * informed about the consumption of this source.
+     *
+     * @param source The input stream source generator.
+     * @param script The conversion script as an input stream source generator.
+     * @return The current conversion specification.
+     */
+    IConversionJobWithSourceUnspecified convert(IInputStreamSource source, IInputStreamSource script);
+
+    /**
+     * Converts a source file that is stored on the local file system.
+     *
+     * @param source The conversion input as a file.
+     * @param script The conversion script as a file.
+     * @return The current conversion specification.
+     */
+    IConversionJobWithSourceUnspecified convert(File source, File script);
+
+    /**
+     * Invokes a callback for the dynamic generation of a file source which is additionally informed
+     * about the consumption of a source.
+     *
+     * @param source The file source generator.
+     * @param script The conversion script as a file source.
+     * @return The current conversion specification.
+     */
+    IConversionJobWithSourceUnspecified convert(IFileSource source, IFileSource script);
 
     /**
      * Returns a mapping of all conversions that are supported by the backing conversion engine.

--- a/documents4j-client/src/main/java/com/documents4j/job/RemoteFutureWrappingPriorityFuture.java
+++ b/documents4j-client/src/main/java/com/documents4j/job/RemoteFutureWrappingPriorityFuture.java
@@ -9,6 +9,8 @@ import com.google.common.base.MoreObjects;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
+
+import java.io.File;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -52,13 +54,18 @@ class RemoteFutureWrappingPriorityFuture extends AbstractFutureWrappingPriorityF
     }
 
     @Override
-    protected RemoteConversionContext startConversion(InputStream fetchedSource) {
+    protected RemoteConversionContext startConversion(InputStream fetchedSource, File script) {
+    	
+    	// TODO handle script
+    	
         return new RemoteConversionContext(webTarget
                 .path(ConverterNetworkProtocol.RESOURCE_PATH)
                 .request(targetFormat.toString())
                 .header(ConverterNetworkProtocol.HEADER_JOB_PRIORITY, getPriority().getValue())
                 .async()
-                .post(Entity.entity(new ConsumeOnCloseInputStream(this, fetchedSource), sourceFormat.toString())));
+                .post(Entity.entity(
+                		new ConsumeOnCloseInputStream(this, fetchedSource), 
+                		sourceFormat.toString())));
     }
 
     @Override
@@ -92,4 +99,11 @@ class RemoteFutureWrappingPriorityFuture extends AbstractFutureWrappingPriorityF
                 .add("web-target", webTarget.getUri())
                 .toString();
     }
+
+	@Override
+	protected File fetchScript() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/documents4j-local/src/main/java/com/documents4j/job/LocalFutureWrappingPriorityFuture.java
+++ b/documents4j-local/src/main/java/com/documents4j/job/LocalFutureWrappingPriorityFuture.java
@@ -25,6 +25,7 @@ class LocalFutureWrappingPriorityFuture extends AbstractFutureWrappingPriorityFu
                                       File target,
                                       IFileConsumer callback,
                                       DocumentType targetFormat,
+                                      IFileSource script,
                                       int priority) {
         super(priority);
         this.conversionManager = conversionManager;
@@ -33,6 +34,7 @@ class LocalFutureWrappingPriorityFuture extends AbstractFutureWrappingPriorityFu
         this.target = target;
         this.callback = callback;
         this.targetFormat = targetFormat;
+        this.script = script;
     }
 
     @Override
@@ -45,9 +47,22 @@ class LocalFutureWrappingPriorityFuture extends AbstractFutureWrappingPriorityFu
         source.onConsumed(fetchedSource);
     }
 
+    
+    private IFileSource script; 
+	@Override
+	protected File fetchScript() {
+		if (script==null) {
+			return null;
+		} else {
+			return script.getFile();
+		}
+	}
+    
     @Override
-    protected LocalConversionContext startConversion(File fetchedSource) {
-        return new LocalConversionContext(conversionManager.startConversion(fetchedSource, sourceFormat, target, targetFormat));
+    protected LocalConversionContext startConversion(File fetchedSource, File script) {
+    	
+        return new LocalConversionContext(
+        		conversionManager.startConversion(fetchedSource, sourceFormat, target, targetFormat, script));
     }
 
     @Override
@@ -75,4 +90,5 @@ class LocalFutureWrappingPriorityFuture extends AbstractFutureWrappingPriorityFu
                 .add("file-system-target", target)
                 .toString();
     }
+
 }

--- a/documents4j-local/src/test/java/com/documents4j/conversion/MockConversionManager.java
+++ b/documents4j-local/src/test/java/com/documents4j/conversion/MockConversionManager.java
@@ -39,7 +39,7 @@ public abstract class MockConversionManager implements IConversionManager {
     }
 
     @Override
-    public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat) {
+    public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat, File script) {
         if (!sourceFormat.equals(AbstractConverterTest.MOCK_INPUT_TYPE) || !targetFormat.equals(AbstractConverterTest.MOCK_RESPONSE_TYPE)) {
             return MockResult.indicating(new ConversionFormatException("Unknown input/output format conversion"));
         }

--- a/documents4j-server-standalone/src/test/java/com/documents4j/job/PseudoConverter.java
+++ b/documents4j-server-standalone/src/test/java/com/documents4j/job/PseudoConverter.java
@@ -19,7 +19,8 @@ public class PseudoConverter implements IExternalConverter {
     public Future<Boolean> startConversion(File source,
                                            DocumentType sourceFormat,
                                            File target,
-                                           DocumentType targetType) {
+                                           DocumentType targetType,
+                                           File script) {
         throw new AssertionError();
     }
 

--- a/documents4j-transformer-api/src/main/java/com/documents4j/conversion/IExternalConverter.java
+++ b/documents4j-transformer-api/src/main/java/com/documents4j/conversion/IExternalConverter.java
@@ -17,10 +17,11 @@ public interface IExternalConverter {
      * @param sourceFormat The file format of the source file.
      * @param target       The target file to which the converted file should be saved.
      * @param targetFormat The file format of the target file.
+     * @param script       A specific script to use for the conversion (can be null).
      * @return A future that represents a pending conversion where the enclosed {@code boolean} represents the
      * conversion's success.
      */
-    Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat);
+    Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat, File script);
 
     /**
      * Checks if this converter back-end is operational.

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/test/java/com/documents4j/conversion/msoffice/MicrosoftExcelConversionTest.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/test/java/com/documents4j/conversion/msoffice/MicrosoftExcelConversionTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -40,4 +41,14 @@ public class MicrosoftExcelConversionTest extends AbstractMicrosoftOfficeConvers
     public static void setUpConverter() throws Exception {
         AbstractMicrosoftOfficeConversionTest.setUp(MicrosoftExcelBridge.class, MicrosoftExcelScript.ASSERTION, MicrosoftExcelScript.SHUTDOWN);
     }
+    
+	@Override
+	public File getUserScript() {
+		
+		// Its OK to use the standard script here
+		MicrosoftOfficeScript script = MicrosoftExcelScript.CONVERSION;
+		return script.materializeIn(getFileFolder());
+		
+	}
+    
 }

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/test/java/com/documents4j/conversion/msoffice/MicrosoftExcelInaccessibilityTest.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/test/java/com/documents4j/conversion/msoffice/MicrosoftExcelInaccessibilityTest.java
@@ -1,6 +1,9 @@
 package com.documents4j.conversion.msoffice;
 
 import com.documents4j.api.DocumentType;
+
+import java.io.File;
+
 import org.junit.BeforeClass;
 
 public class MicrosoftExcelInaccessibilityTest extends AbstractMicrosoftOfficeInaccessibilityTest {
@@ -19,4 +22,11 @@ public class MicrosoftExcelInaccessibilityTest extends AbstractMicrosoftOfficeIn
     public static void setUpConverter() throws Exception {
         AbstractMicrosoftOfficeConversionTest.setUp(MicrosoftExcelBridge.class, MicrosoftExcelScript.ASSERTION, MicrosoftExcelScript.SHUTDOWN);
     }
+    
+	@Override
+	public File getUserScript() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+    
 }

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-test/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBasedTest.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-test/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBasedTest.java
@@ -16,14 +16,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 
-public class AbstractMicrosoftOfficeBasedTest extends AbstractMicrosoftOfficeAssertingTest {
+public abstract class AbstractMicrosoftOfficeBasedTest extends AbstractMicrosoftOfficeAssertingTest {
 
     private static File externalConverterDirectory;
     private static AbstractMicrosoftOfficeBridge externalConverter;
     protected final DocumentTypeProvider documentTypeProvider;
     private AtomicInteger nameGenerator;
     private File files;
-    private Set<File> fileCopies;
+    protected Set<File> fileCopies;
 
     protected AbstractMicrosoftOfficeBasedTest(DocumentTypeProvider documentTypeProvider) {
         this.documentTypeProvider = documentTypeProvider;
@@ -143,4 +143,6 @@ public class AbstractMicrosoftOfficeBasedTest extends AbstractMicrosoftOfficeAss
         }
         return target;
     }
+    
+    abstract public File getUserScript();
 }

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-test/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeInaccessibilityTest.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-test/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeInaccessibilityTest.java
@@ -22,7 +22,7 @@ public abstract class AbstractMicrosoftOfficeInaccessibilityTest extends Abstrac
         getAssertionEngine().kill();
         assertTrue(otherFolder.delete());
         File target = makeTarget(false);
-        assertEquals(getOfficeBridge().doStartConversion(validSourceFile(true), getSourceDocumentType(), target, getTargetDocumentType())
+        assertEquals(getOfficeBridge().doStartConversion(validSourceFile(true), getSourceDocumentType(), target, getTargetDocumentType(), null)
                         .getFuture().get().getExitValue(),
                 ExternalConverterScriptResult.CONVERTER_INACCESSIBLE.getExitValue().intValue());
         assertFalse(target.exists());

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/test/java/com/documents4j/conversion/msoffice/MicrosoftWordConversionTest.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/test/java/com/documents4j/conversion/msoffice/MicrosoftWordConversionTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -47,4 +48,13 @@ public class MicrosoftWordConversionTest extends AbstractMicrosoftOfficeConversi
     public static void setUpConverter() throws Exception {
         AbstractMicrosoftOfficeConversionTest.setUp(MicrosoftWordBridge.class, MicrosoftWordScript.ASSERTION, MicrosoftWordScript.SHUTDOWN);
     }
+
+	@Override
+	public File getUserScript() {
+		
+		// Its OK to use the standard script here
+		MicrosoftOfficeScript script = MicrosoftWordScript.CONVERSION;
+		return script.materializeIn(getFileFolder());
+		
+	}
 }

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/test/java/com/documents4j/conversion/msoffice/MicrosoftWordInaccessibilityTest.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/test/java/com/documents4j/conversion/msoffice/MicrosoftWordInaccessibilityTest.java
@@ -1,6 +1,9 @@
 package com.documents4j.conversion.msoffice;
 
 import com.documents4j.api.DocumentType;
+
+import java.io.File;
+
 import org.junit.BeforeClass;
 
 public class MicrosoftWordInaccessibilityTest extends AbstractMicrosoftOfficeInaccessibilityTest {
@@ -21,4 +24,10 @@ public class MicrosoftWordInaccessibilityTest extends AbstractMicrosoftOfficeIna
                 MicrosoftWordScript.ASSERTION,
                 MicrosoftWordScript.SHUTDOWN);
     }
+
+	@Override
+	public File getUserScript() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/documents4j-transformer/src/main/java/com/documents4j/conversion/DefaultConversionManager.java
+++ b/documents4j-transformer/src/main/java/com/documents4j/conversion/DefaultConversionManager.java
@@ -26,8 +26,10 @@ public class DefaultConversionManager implements IConversionManager {
     }
 
     @Override
-    public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat) {
-        return converterRegistry.lookup(sourceFormat, targetFormat).startConversion(source, sourceFormat, target, targetFormat);
+    public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat,
+    		File script) {
+    	IExternalConverter externalConverter = converterRegistry.lookup(sourceFormat, targetFormat);
+        return externalConverter.startConversion(source, sourceFormat, target, targetFormat, script);
     }
 
     @Override

--- a/documents4j-transformer/src/main/java/com/documents4j/conversion/IConversionManager.java
+++ b/documents4j-transformer/src/main/java/com/documents4j/conversion/IConversionManager.java
@@ -19,10 +19,11 @@ public interface IConversionManager {
      * @param sourceFormat The file format of the source file.
      * @param target       The target file to which the converted file should be saved.
      * @param targetFormat The file format of the target file.
+     * @param script       A specific script to use for the conversion (can be null).
      * @return A future that represents a pending conversion where the enclosed {@code boolean} represents the
      * conversion's success.
      */
-    Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat);
+    Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat, File script);
 
     /**
      * Returns a mapping of all conversions that are supported by the backing conversion engine.

--- a/documents4j-transformer/src/test/java/com/documents4j/conversion/ConverterRegistryTest.java
+++ b/documents4j-transformer/src/test/java/com/documents4j/conversion/ConverterRegistryTest.java
@@ -50,7 +50,7 @@ public class ConverterRegistryTest {
     private static class ViableAnnotationMock implements IExternalConverter {
 
         @Override
-        public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat) {
+        public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat, File script) {
             throw new AssertionError();
         }
 
@@ -69,7 +69,7 @@ public class ConverterRegistryTest {
     private static class ViableAnnotationsMock implements IExternalConverter {
 
         @Override
-        public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat) {
+        public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat, File script) {
             throw new AssertionError();
         }
 

--- a/documents4j-transformer/src/test/java/com/documents4j/conversion/DefaultConversionManagerTest.java
+++ b/documents4j-transformer/src/test/java/com/documents4j/conversion/DefaultConversionManagerTest.java
@@ -63,11 +63,12 @@ public class DefaultConversionManagerTest {
         conversionManager.startConversion(source,
                 SOURCE_FORMAT,
                 target,
-                TARGET_FORMAT);
+                TARGET_FORMAT,
+                null);
         conversionManager.shutDown();
 
         MockExternalConverter bridge = extractConverter(conversionManager);
-        verify(bridge.getDelegate()).startConversion(source, SOURCE_FORMAT, target, TARGET_FORMAT);
+        verify(bridge.getDelegate()).startConversion(source, SOURCE_FORMAT, target, TARGET_FORMAT, null);
         verify(bridge.getDelegate()).shutDown();
         verifyNoMoreInteractions(bridge.getDelegate());
     }

--- a/documents4j-transformer/src/test/java/com/documents4j/conversion/ExternalConverterDiscoveryTest.java
+++ b/documents4j-transformer/src/test/java/com/documents4j/conversion/ExternalConverterDiscoveryTest.java
@@ -60,7 +60,7 @@ public class ExternalConverterDiscoveryTest {
     public static class IllegalConverter implements IExternalConverter {
 
         @Override
-        public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetType) {
+        public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetType, File script) {
             throw new AssertionError();
         }
 

--- a/documents4j-transformer/src/test/java/com/documents4j/conversion/MockExternalConverter.java
+++ b/documents4j-transformer/src/test/java/com/documents4j/conversion/MockExternalConverter.java
@@ -31,8 +31,8 @@ public class MockExternalConverter implements IExternalConverter {
     }
 
     @Override
-    public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat) {
-        return delegate.startConversion(source, sourceFormat, target, targetFormat);
+    public Future<Boolean> startConversion(File source, DocumentType sourceFormat, File target, DocumentType targetFormat, File script) {
+        return delegate.startConversion(source, sourceFormat, target, targetFormat, script);
     }
 
     public IExternalConverter getDelegate() {

--- a/documents4j-util-conversion/src/main/java/com/documents4j/job/AbstractFutureWrappingPriorityFuture.java
+++ b/documents4j-util-conversion/src/main/java/com/documents4j/job/AbstractFutureWrappingPriorityFuture.java
@@ -5,6 +5,7 @@ import com.documents4j.throwables.ConverterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.concurrent.*;
 
 abstract class AbstractFutureWrappingPriorityFuture<T, S extends IConversionContext>
@@ -67,7 +68,7 @@ abstract class AbstractFutureWrappingPriorityFuture<T, S extends IConversionCont
                     if (underlyingFuture.isCancelled()) {
                         return;
                     }
-                    conversionContext = startConversion(source);
+                    conversionContext = startConversion(source, fetchScript());
                     logger.trace("Context fetched for source {}: {}", source, conversionContext);
                     underlyingFuture = conversionFuture = conversionContext.asFuture();
                     logger.trace("Underlying future created for source {}: {}", source, conversionFuture);
@@ -178,10 +179,15 @@ abstract class AbstractFutureWrappingPriorityFuture<T, S extends IConversionCont
     }
 
     protected abstract T fetchSource();
+    protected abstract File fetchScript();
 
     protected abstract void onSourceConsumed(T fetchedSource);
 
-    protected abstract S startConversion(T fetchedSource);
+    protected abstract S startConversion(T fetchedSource, File script);
+
+    protected S startConversion(T fetchedSource) {
+    	return startConversion(fetchedSource, null);
+    }
 
     protected abstract void onConversionFinished(S conversionContext) throws Exception;
 

--- a/documents4j-util-conversion/src/main/java/com/documents4j/job/ConverterAdapter.java
+++ b/documents4j-util-conversion/src/main/java/com/documents4j/job/ConverterAdapter.java
@@ -56,30 +56,60 @@ public abstract class ConverterAdapter implements IConverter {
     }
 
     @Override
+    public IConversionJobWithSourceUnspecified convert(File source, File script) {
+        return convert(new FileSourceFromFile(source), new FileSourceFromFile(script));
+    }
+
+    @Override
+    public IConversionJobWithSourceUnspecified convert(InputStream source, InputStream script) {
+        return convert(source, script, DEFAULT_CLOSE_STREAM);
+    }
+
+    @Override
+    public IConversionJobWithSourceUnspecified convert(InputStream source, InputStream script, boolean close) {
+    	// TODO close applies to both inputstreams.  Control independently?
+        return convert(new InputStreamSourceFromInputStream(source, close), 
+        		new InputStreamSourceFromInputStream(script, close));
+    }
+
+    @Override
+    public IConversionJobWithSourceUnspecified convert(IFileSource source, IFileSource script) {
+        return convert(new InputStreamSourceFromFileSource(source), new InputStreamSourceFromFileSource(script));
+    }
+
+    @Override
+    public IConversionJobWithSourceUnspecified convert(IInputStreamSource source, IInputStreamSource script) {
+        return convert(new FileSourceFromInputStreamSource(source, makeTemporaryFile()),
+        		new FileSourceFromInputStreamSource(script, makeTemporaryFile()));
+    }
+
+    @Override
     public IConversionJobWithSourceUnspecified convert(File source) {
-        return convert(new FileSourceFromFile(source));
+        return convert(new FileSourceFromFile(source), null);
     }
 
     @Override
     public IConversionJobWithSourceUnspecified convert(InputStream source) {
-        return convert(source, DEFAULT_CLOSE_STREAM);
+        return convert(source, null, DEFAULT_CLOSE_STREAM);
     }
 
     @Override
     public IConversionJobWithSourceUnspecified convert(InputStream source, boolean close) {
-        return convert(new InputStreamSourceFromInputStream(source, close));
+        return convert(new InputStreamSourceFromInputStream(source, close), 
+        		null);
     }
 
     @Override
     public IConversionJobWithSourceUnspecified convert(IFileSource source) {
-        return convert(new InputStreamSourceFromFileSource(source));
+        return convert(new InputStreamSourceFromFileSource(source), null);
     }
 
     @Override
     public IConversionJobWithSourceUnspecified convert(IInputStreamSource source) {
-        return convert(new FileSourceFromInputStreamSource(source, makeTemporaryFile()));
+        return convert(new FileSourceFromInputStreamSource(source, makeTemporaryFile()),
+        		null);
     }
-
+    
     protected File makeTemporaryFile() {
         return makeTemporaryFile(NO_EXTENSION);
     }
@@ -134,4 +164,5 @@ public abstract class ConverterAdapter implements IConverter {
             shutDown();
         }
     }
+
 }

--- a/documents4j-util-conversion/src/test/java/com/documents4j/job/StubbedFutureWrappingPriorityFuture.java
+++ b/documents4j-util-conversion/src/test/java/com/documents4j/job/StubbedFutureWrappingPriorityFuture.java
@@ -1,5 +1,6 @@
 package com.documents4j.job;
 
+import java.io.File;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -31,11 +32,17 @@ class StubbedFutureWrappingPriorityFuture extends AbstractFutureWrappingPriority
         onSourceConsumed.incrementAndGet();
     }
 
-    @Override
-    protected IConversionContext startConversion(Void fetchedSource) {
+	@Override
+	protected IConversionContext startConversion(Void fetchedSource, File script) {
         startConversion.incrementAndGet();
         return conversionContext;
-    }
+	}
+
+//    @Override
+//    protected IConversionContext startConversion(Void fetchedSource) {
+//        startConversion.incrementAndGet();
+//        return conversionContext;
+//    }
 
     @Override
     protected void onConversionFinished(IConversionContext conversionContext) throws Exception {
@@ -92,4 +99,11 @@ class StubbedFutureWrappingPriorityFuture extends AbstractFutureWrappingPriority
             return future;
         }
     }
+
+	@Override
+	protected File fetchScript() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }


### PR DESCRIPTION
For example `converter.convert(wordFile, myScript).as(DocumentType.MS_WORD)`

I haven't handled the remove conversion case, in which you should be able to pass the user script in the web service call.  See the TODO in RemoteFutureWrappingPriorityFuture.

