### PR TITLE
Excel password lock bug fix

### DIFF
--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.vbs
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.vbs
@@ -29,8 +29,8 @@ Function ConvertFile( inputFile, outputFile, formatEnumeration )
 
     ' Attempt to open the source document. We are using an empty password to suppress any dialog.
     On Error Resume Next
-    Set excelDocument = excelApplication.Workbooks.Open(inputFile, , True, "dummy-password-to-avoid-lock", , , , , , , , , , , 2)
-    If excelDocument = "" OR Err <> 0 Then
+    Set excelDocument = excelApplication.Workbooks.Open(inputFile, , True, ,"dummy-password-to-avoid-lock", , , , , , , , , , 2)
+    If Err <> 0 Then
       WScript.Quit -2
     End If
     On Error GoTo 0


### PR DESCRIPTION
According to the documentation (https://docs.microsoft.com/en-us/office/vba/api/excel.workbooks.open) the password needs to be passed as the 5th argument.