### PR TITLE
Update word_start.vbs

### DIFF
--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_start.vbs
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_start.vbs
@@ -7,6 +7,7 @@ Set wordApplication = GetObject(, "Word.Application")
 If Err = 0 Then
   WScript.Quit 3
 End If
+Err.clear
 
 ' Start MS Word.
 Set wordApplication = CreateObject("Word.Application")


### PR DESCRIPTION
I expect line 7 to check for an error in line 4. I expect line 14 to check for an error on line 13.

Here is what I experience:
- Word is not started in background
- GetObject throws error 427, this error is checked in line 7 and the code continues.
- CreateObject starts word in background without error. Because the Err is not cleared, the Err is still 427 and the script quits with -6

I am not at all experienced with vbs but I expect that -6 should indicate an error. Is seems like this is not checked in the caller because on my machine the conversion is running fine.