### PR TITLE
Update excel_convert.vbs

### DIFF
--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.vbs
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.vbs
@@ -29,7 +29,7 @@ Function ConvertFile( inputFile, outputFile, formatEnumeration )
 
     ' Attempt to open the source document.
     On Error Resume Next
-    Set excelDocument = excelApplication.Workbooks.Open(inputFile, , True, , , , , , , , , , , , 2)
+    Set excelDocument = excelApplication.Workbooks.Open(inputFile, , True)
     If Err <> 0 Then
       WScript.Quit -2
     End If


### PR DESCRIPTION
The argument "2" in ```excelApplication.Workbooks.Open``` is causing the converted PDF to lose formatting as defined in the Excel file. Referring to Microsoft's VBA reference [Workbooks.Open method (Excel)](https://docs.microsoft.com/en-us/office/vba/api/excel.workbooks.open), it seems that the last option ```CorruptLoad```, when it's set to ```xlExtractData```(2), the workbook will be opened in Extract data mode.

Example Files:
[input.xlsx](https://github.com/documents4j/documents4j/files/5200547/input.xlsx)

```output1.pdf``` has formatting successfully converted, ```output2.pdf``` has formatting lost.
[output1.pdf](https://github.com/documents4j/documents4j/files/5200548/output1.pdf)
[output2.pdf](https://github.com/documents4j/documents4j/files/5200549/output2.pdf)


The following VBScript (run with WScript) can be used to test the behaviour:

```

Dim fileSystemObject
Dim excelApplication
Dim excelDocument 

Set excelApplication = GetObject(, "Excel.Application")

Set fileSystemObject = CreateObject("Scripting.FileSystemObject")
inputFile = fileSystemObject.GetAbsolutePathName("input.xlsx")

Set excelDocument = excelApplication.Workbooks.Open(inputFile, , True)
'Set excelDocument = excelApplication.Workbooks.Open(inputFile, , True, , , , , , , , , , , , 2)
 
excelDocument.ExportAsFixedFormat xlTypePDF, fileSystemObject.GetAbsolutePathName("out.pdf")
 
excelDocument.Close False
```
