### PR TITLE
Make convert to docx writes to docx(no marco) file on all machines.

### DIFF
--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/java/com/documents4j/conversion/msoffice/MicrosoftWordFormat.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/java/com/documents4j/conversion/msoffice/MicrosoftWordFormat.java
@@ -9,7 +9,7 @@ enum MicrosoftWordFormat implements MicrosoftOfficeFormat {
 
     PDF("17", "pdf", DocumentType.PDF),
     PDFA("999", "pdf", DocumentType.PDFA),
-    DOCX("16", "docx", DocumentType.DOCX),
+    DOCX("12", "docx", DocumentType.DOCX),
     DOC("0", "doc", DocumentType.DOC),
     RTF("6", "rtf", DocumentType.RTF),
     MHTML("9", "mht", DocumentType.MHTML),


### PR DESCRIPTION
Using output type 16 on my machine(MS Office 2013 x86 installed) results `.doc` file instead of `.docx`.
According to https://docs.microsoft.com/en-us/dotnet/api/microsoft.office.interop.word.wdsaveformat?view=word-pia 
Changing type enum to 12 results `.docx` file on my computer, or using 13 for docx with macro.
fixes #122