### PR TITLE
Transform ArrayList to LinkedList for Performance Improvement

### DIFF
--- a/documents4j-aggregation/src/main/java/com/documents4j/job/AggregatingConverter.java
+++ b/documents4j-aggregation/src/main/java/com/documents4j/job/AggregatingConverter.java
@@ -174,7 +174,7 @@ public class AggregatingConverter implements IAggregatingConverter, IConverterFa
         }
         try {
             if (propagateShutDown) {
-                List<RuntimeException> exceptions = new ArrayList<RuntimeException>();
+                List<RuntimeException> exceptions = new LinkedList<RuntimeException>();
                 for (IConverter converter : converters) {
                     try {
                         converter.shutDown();
@@ -198,7 +198,7 @@ public class AggregatingConverter implements IAggregatingConverter, IConverterFa
         }
         try {
             if (propagateShutDown) {
-                List<RuntimeException> exceptions = new ArrayList<RuntimeException>();
+                List<RuntimeException> exceptions = new LinkedList<RuntimeException>();
                 for (IConverter converter : converters) {
                     try {
                         converter.kill();


### PR DESCRIPTION
Hi,
We find that there are two List objects allocated at line 85 in the file AggregatingConverter.java which are inserted in a loop. Due to the memory reallocation triggered in the successive insertions, the time complexity of add method of ArrayList is amortized O(1). We notice that these two ArrayList objects are only used for traversal and the retrieval for the first element. This functionality can be implemented by LinkedList. Moreover, the insertion of LinkedList is strictly O(1) time complexity because no memory reallocation occurs.

We discovered this inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto