### PR TITLE
MacOS scripts for Excel and Word

### DIFF
--- a/documents4j-transformer-api/src/main/java/com/documents4j/conversion/ExternalConverterScriptResult.java
+++ b/documents4j-transformer-api/src/main/java/com/documents4j/conversion/ExternalConverterScriptResult.java
@@ -1,5 +1,6 @@
 package com.documents4j.conversion;
 
+import com.documents4j.util.OsUtils;
 import com.documents4j.util.Reaction;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -13,7 +14,7 @@ public enum ExternalConverterScriptResult {
     /**
      * Represents a successful conversion of a file.
      */
-    CONVERSION_SUCCESSFUL(2, Reaction.with(true)),
+    CONVERSION_SUCCESSFUL(OsUtils.isWindows() ? 2 : 0, Reaction.with(true)),
 
     /**
      * Represents a successful interaction with an external converter.

--- a/documents4j-transformer-api/src/main/java/com/documents4j/conversion/ExternalConverterScriptResult.java
+++ b/documents4j-transformer-api/src/main/java/com/documents4j/conversion/ExternalConverterScriptResult.java
@@ -1,6 +1,5 @@
 package com.documents4j.conversion;
 
-import com.documents4j.util.OsUtils;
 import com.documents4j.util.Reaction;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;

--- a/documents4j-transformer-api/src/main/java/com/documents4j/conversion/ExternalConverterScriptResult.java
+++ b/documents4j-transformer-api/src/main/java/com/documents4j/conversion/ExternalConverterScriptResult.java
@@ -14,7 +14,7 @@ public enum ExternalConverterScriptResult {
     /**
      * Represents a successful conversion of a file.
      */
-    CONVERSION_SUCCESSFUL(OsUtils.isWindows() ? 2 : 0, Reaction.with(true)),
+    CONVERSION_SUCCESSFUL(2, Reaction.with(true)),
 
     /**
      * Represents a successful interaction with an external converter.

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
@@ -5,6 +5,7 @@ import com.documents4j.conversion.AbstractExternalConverter;
 import com.documents4j.conversion.ExternalConverterScriptResult;
 import com.documents4j.conversion.ProcessFutureWrapper;
 import com.documents4j.throwables.ConverterAccessException;
+import com.documents4j.util.OsUtils;
 import com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
 import org.zeroturnaround.exec.StartedProcess;
@@ -65,12 +66,20 @@ public abstract class AbstractMicrosoftOfficeBridge extends AbstractExternalConv
         try {
             MicrosoftOfficeFormat microsoftOfficeFormat = formatOf(targetType);
             // Always call destroyOnExit before adding a listener: https://github.com/zeroturnaround/zt-exec/issues/14
-            String[] command = {"cmd", "/S", "/C",
-                    doubleQuote(conversionScript.getAbsolutePath(),
-                            source.getAbsolutePath(),
-                            target.getAbsolutePath(),
-                            microsoftOfficeFormat.getValue())};
-
+            String[] command = null;
+            if (OsUtils.isWindows()) {
+                command = new String[]{"cmd", "/S", "/C",
+                        doubleQuote(conversionScript.getAbsolutePath(),
+                                source.getAbsolutePath(),
+                                target.getAbsolutePath(),
+                                microsoftOfficeFormat.getValue())};
+            } else if (OsUtils.isMac()) {
+                command = new String[]{"osascript",
+                        doubleQuote(conversionScript.getAbsolutePath(),
+                                source.getAbsolutePath(),
+                                target.getAbsolutePath(),
+                                microsoftOfficeFormat.getValue())};
+            }
             getLogger().trace("Running command for conversion {},", Arrays.toString(command));
 
             return makePresetProcessExecutor()

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
@@ -75,37 +75,13 @@ public abstract class AbstractMicrosoftOfficeBridge extends AbstractExternalConv
                                 target.getAbsolutePath(),
                                 microsoftOfficeFormat.getValue())};
             } else if (OsUtils.isMac()) {
-                command = new String[]{"zsh", "-c", "\"osascript " +
-                                       conversionScript.getAbsolutePath() + " " +
-                                       source.getAbsolutePath() + " " +
-                                       target.getAbsolutePath() + " " + 
-                                       microsoftOfficeFormat.getValue() + "\""};
+                command = new String[]{"/usr/bin/osascript",                                  
+                					   conversionScript.getAbsolutePath(),
+                                       source.getAbsolutePath(),
+                                       target.getAbsolutePath(),
+                                       microsoftOfficeFormat.getValue()};
             }
             getLogger().info("Running command for conversion '{}'", Arrays.toString(command));
-            
-//            ProcessBuilder processBuilder = new ProcessBuilder();
-//            processBuilder.command(command);
-//            try {
-//
-//                Process process = processBuilder.start();
-//
-//                BufferedReader reader = new BufferedReader(
-//                        new InputStreamReader(process.getErrorStream()));
-//
-//                     String line;
-//                     while ((line = reader.readLine()) != null) {
-//                        System.out.println("E: " + line);
-//                    }
-//
-//
-//                int success = process.waitFor();
-//                
-//                System.out.println("succ: " + success);
-                // check the status
-//            } catch (IOException | InterruptedException e) {
-//                // do some logging
-//            }
-            
             
             return makePresetProcessExecutor()
                     .command(command)

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
@@ -2,11 +2,13 @@ package com.documents4j.conversion.msoffice;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
+import org.zeroturnaround.exec.ProcessExecutor;
 import org.zeroturnaround.exec.StartedProcess;
 
 import com.documents4j.api.DocumentType;
@@ -16,20 +18,7 @@ import com.documents4j.conversion.ProcessFutureWrapper;
 import com.documents4j.throwables.ConverterAccessException;
 import com.documents4j.util.OsUtils;
 import com.google.common.base.MoreObjects;
-
 import com.google.common.base.Supplier;
-import org.slf4j.Logger;
-import org.zeroturnaround.exec.ProcessExecutor;
-import org.zeroturnaround.exec.StartedProcess;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -86,10 +75,12 @@ public abstract class AbstractMicrosoftOfficeBridge extends AbstractExternalConv
     @Override
     public Future<Boolean> startConversion(File source, DocumentType sourceType, File target, DocumentType targetType) {
         if (exitCodeFromStandardOutput) {
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             return new ProcessFutureWrapper(
-                    doStartConversion(source, sourceType, target, targetType, () -> makePresetProcessExecutor(outputStream)),
-                    processResult -> Integer.parseInt(new String(outputStream.toByteArray(), StandardCharsets.UTF_8)));
+                    doStartConversion(source, sourceType, target, targetType, () -> makePresetProcessExecutor()),
+                    processResult -> {
+                    	String s = new String(processResult.output(), StandardCharsets.UTF_8).replaceAll("\r\n", " ").trim(); 
+                    	return Integer.parseInt(s);
+                    });
         } else {
             return new ProcessFutureWrapper(doStartConversion(source, sourceType, target, targetType));
         }

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
@@ -1,5 +1,14 @@
 package com.documents4j.conversion.msoffice;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.zeroturnaround.exec.StartedProcess;
+
 import com.documents4j.api.DocumentType;
 import com.documents4j.conversion.AbstractExternalConverter;
 import com.documents4j.conversion.ExternalConverterScriptResult;
@@ -7,14 +16,6 @@ import com.documents4j.conversion.ProcessFutureWrapper;
 import com.documents4j.throwables.ConverterAccessException;
 import com.documents4j.util.OsUtils;
 import com.google.common.base.MoreObjects;
-import org.slf4j.Logger;
-import org.zeroturnaround.exec.StartedProcess;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A base implementation of converting a file using a MS Office component.
@@ -74,14 +75,38 @@ public abstract class AbstractMicrosoftOfficeBridge extends AbstractExternalConv
                                 target.getAbsolutePath(),
                                 microsoftOfficeFormat.getValue())};
             } else if (OsUtils.isMac()) {
-                command = new String[]{"osascript",
-                        doubleQuote(conversionScript.getAbsolutePath(),
-                                source.getAbsolutePath(),
-                                target.getAbsolutePath(),
-                                microsoftOfficeFormat.getValue())};
+                command = new String[]{"zsh", "-c", "\"osascript " +
+                                       conversionScript.getAbsolutePath() + " " +
+                                       source.getAbsolutePath() + " " +
+                                       target.getAbsolutePath() + " " + 
+                                       microsoftOfficeFormat.getValue() + "\""};
             }
-            getLogger().trace("Running command for conversion {},", Arrays.toString(command));
-
+            getLogger().info("Running command for conversion '{}'", Arrays.toString(command));
+            
+//            ProcessBuilder processBuilder = new ProcessBuilder();
+//            processBuilder.command(command);
+//            try {
+//
+//                Process process = processBuilder.start();
+//
+//                BufferedReader reader = new BufferedReader(
+//                        new InputStreamReader(process.getErrorStream()));
+//
+//                     String line;
+//                     while ((line = reader.readLine()) != null) {
+//                        System.out.println("E: " + line);
+//                    }
+//
+//
+//                int success = process.waitFor();
+//                
+//                System.out.println("succ: " + success);
+                // check the status
+//            } catch (IOException | InterruptedException e) {
+//                // do some logging
+//            }
+            
+            
             return makePresetProcessExecutor()
                     .command(command)
                     .destroyOnExit()

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/main/java/com/documents4j/conversion/msoffice/AbstractMicrosoftOfficeBridge.java
@@ -78,8 +78,8 @@ public abstract class AbstractMicrosoftOfficeBridge extends AbstractExternalConv
             return new ProcessFutureWrapper(
                     doStartConversion(source, sourceType, target, targetType, () -> makePresetProcessExecutor()),
                     processResult -> {
-                    	String s = new String(processResult.output(), StandardCharsets.UTF_8).replaceAll("\r\n", " ").trim(); 
-                    	return Integer.parseInt(s);
+                        String s = new String(processResult.output(), StandardCharsets.UTF_8).replaceAll("\r\n", " ").trim();
+                        return Integer.parseInt(s);
                     });
         } else {
             return new ProcessFutureWrapper(doStartConversion(source, sourceType, target, targetType));
@@ -103,14 +103,14 @@ public abstract class AbstractMicrosoftOfficeBridge extends AbstractExternalConv
                                 target.getAbsolutePath(),
                                 microsoftOfficeFormat.getValue())};
             } else if (OsUtils.isMac()) {
-                command = new String[]{"/usr/bin/osascript",                                  
-                					   conversionScript.getAbsolutePath(),
+                command = new String[]{"/usr/bin/osascript",
+                                       conversionScript.getAbsolutePath(),
                                        source.getAbsolutePath(),
                                        target.getAbsolutePath(),
                                        microsoftOfficeFormat.getValue()};
             }
             getLogger().info("Running command for conversion '{}'", Arrays.toString(command));
-            
+
            return executorSupplier.get()
                     .command(command)
                     .destroyOnExit()

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/test/java/com/documents4j/conversion/msoffice/MicrosoftOfficeTargetNameCorrectorTest.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-base/src/test/java/com/documents4j/conversion/msoffice/MicrosoftOfficeTargetNameCorrectorTest.java
@@ -2,6 +2,7 @@ package com.documents4j.conversion.msoffice;
 
 import com.documents4j.conversion.ExternalConverterScriptResult;
 import com.documents4j.throwables.FileSystemInteractionException;
+import com.documents4j.util.OsUtils;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.After;
@@ -9,6 +10,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -89,7 +93,8 @@ public class MicrosoftOfficeTargetNameCorrectorTest {
 
     @Test(expected = FileSystemInteractionException.class)
     public void testRenamingProcessSuccessfulFileWithoutFileNameExtensionBlocked() throws Exception {
-        Process process = Mockito.mock(Process.class);
+    	assumeTrue(OsUtils.isWindows());
+    	Process process = Mockito.mock(Process.class);
         Mockito.when(process.exitValue()).thenReturn(ExternalConverterScriptResult.CONVERSION_SUCCESSFUL.getExitValue());
 
         File target = makeFile("." + FOO);

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/java/com/documents4j/conversion/msoffice/MicrosoftExcelBridge.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/java/com/documents4j/conversion/msoffice/MicrosoftExcelBridge.java
@@ -2,6 +2,8 @@ package com.documents4j.conversion.msoffice;
 
 import com.documents4j.api.DocumentType;
 import com.documents4j.conversion.ViableConversion;
+import com.documents4j.util.OsUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +43,7 @@ public class MicrosoftExcelBridge extends AbstractMicrosoftOfficeBridge {
     private static final Semaphore CONVERSION_LOCK = new Semaphore(1, true);
 
     public MicrosoftExcelBridge(File baseFolder, long processTimeout, TimeUnit processTimeoutUnit) {
-        super(baseFolder, processTimeout, processTimeoutUnit, MicrosoftExcelScript.CONVERSION);
+        super(baseFolder, processTimeout, processTimeoutUnit, MicrosoftExcelScript.CONVERSION, OsUtils.isMac());
         startUp();
     }
 

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/java/com/documents4j/conversion/msoffice/MicrosoftExcelScript.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/java/com/documents4j/conversion/msoffice/MicrosoftExcelScript.java
@@ -17,10 +17,10 @@ import java.util.Random;
  */
 enum MicrosoftExcelScript implements MicrosoftOfficeScript {
 
-    CONVERSION("/excel_convert" + (OsUtils.isWindows()?".vbs":(OsUtils.isMac()?".applescript":".sh"))),
-    STARTUP("/excel_start" + (OsUtils.isWindows()?".vbs":(OsUtils.isMac()?".applescript":".sh"))),
-    SHUTDOWN("/excel_shutdown" + (OsUtils.isWindows()?".vbs":(OsUtils.isMac()?".applescript":".sh"))),
-    ASSERTION("/excel_assert" + (OsUtils.isWindows()?".vbs":(OsUtils.isMac()?".applescript":".sh")));
+    CONVERSION("/excel_convert" + (OsUtils.isWindows() ? ".vbs" : (OsUtils.isMac() ? ".applescript" : ".sh"))),
+    STARTUP("/excel_start" + (OsUtils.isWindows() ? ".vbs" : (OsUtils.isMac() ? ".applescript" : ".sh"))),
+    SHUTDOWN("/excel_shutdown" + (OsUtils.isWindows() ? ".vbs" : (OsUtils.isMac() ? ".applescript" : ".sh"))),
+    ASSERTION("/excel_assert" + (OsUtils.isWindows() ? ".vbs" : (OsUtils.isMac() ? ".applescript" : ".sh")));
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MicrosoftExcelBridge.class);
     private static final Random RANDOM = new Random();

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/java/com/documents4j/conversion/msoffice/MicrosoftExcelScript.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/java/com/documents4j/conversion/msoffice/MicrosoftExcelScript.java
@@ -1,6 +1,7 @@
 package com.documents4j.conversion.msoffice;
 
 import com.documents4j.throwables.FileSystemInteractionException;
+import com.documents4j.util.OsUtils;
 import com.google.common.base.MoreObjects;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
@@ -16,10 +17,10 @@ import java.util.Random;
  */
 enum MicrosoftExcelScript implements MicrosoftOfficeScript {
 
-    CONVERSION("/excel_convert.vbs"),
-    STARTUP("/excel_start.vbs"),
-    SHUTDOWN("/excel_shutdown.vbs"),
-    ASSERTION("/excel_assert.vbs");
+    CONVERSION("/excel_convert" + (OsUtils.isWindows()?".vbs":(OsUtils.isMac()?".applescript":".sh"))),
+    STARTUP("/excel_start" + (OsUtils.isWindows()?".vbs":(OsUtils.isMac()?".applescript":".sh"))),
+    SHUTDOWN("/excel_shutdown" + (OsUtils.isWindows()?".vbs":(OsUtils.isMac()?".applescript":".sh"))),
+    ASSERTION("/excel_assert" + (OsUtils.isWindows()?".vbs":(OsUtils.isMac()?".applescript":".sh")));
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MicrosoftExcelBridge.class);
     private static final Random RANDOM = new Random();

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_assert.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_assert.applescript
@@ -1,0 +1,11 @@
+set appName to "Microsoft Excel"
+
+try 
+if application appName is running then
+    return 3 -- everything okay, excel is already running
+else  -- excel not running, start it
+	return -6 
+end if
+on error errMsg number errorNumber
+	return -6
+end try

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.applescript
@@ -1,24 +1,42 @@
-# See http://msdn.microsoft.com/en-us/library/bb243311%28v=office.12%29.aspx
-set WdExportFormatPDF to 17
-set MagicFormatPDF to 999
-set appName to "Microsoft Excel"
-
-on fun argv
-	try 
-		tell application appName
-			open (quoted form of (item 1 of argv))
-			
-			if formatEnumeration = MagicFormatPDF then
-				save workbook as workbook (active workbook) filename (quoted form of (item 2 of argv)) file format (PDF file format) with overwrite
-			else
-			    save workbook as workbook (active workbook) filename (quoted form of (item 2 of argv)) file format ((item 3 of argv) file format) with overwrite
-			end if
-			
-			close (active workbook) saving no
-			
-			return 2
+on run argv
+	set MagicFormatPDF to 999
+	set appName to "Microsoft Excel"
+	try
+		-- get a posix file object to avoid grant access issue with 'Microsoft Office 2016',  not the same as (file documentPath) when using the 'open  ...' command
+		set tFile to (POSIX path of (item 1 of argv)) as POSIX file
+		set PDFFile to (POSIX path of (item 2 of argv)) as POSIX file
+		--tell application "Finder"
+		if fileExists(PDFFile) then
+			tell application "Finder"
+			delete file PDFFile
+			end tell
+		end if
+		--end tell
+		tell application "Microsoft Excel"
+			set isRun to running
+			activate
+			open tFile
+			tell active workbook
+				alias PDFFile -- This is necessary to any script for 'Microsoft Office 2016', this avoid errors with any "save ... " command
+				set wkbk1 to active workbook
+				save as active sheet filename PDFFile file format PDF file format with overwrite
+				close saving no
+			end tell
 		end tell
+		return 2
 	on error errMsg number errorNumber
+		log ("ERROR: ")
+		log (errMsg)
+		tell application appName to quit
 		return -6
 	end try
-end run	
+end run
+on fileExists(theFile) -- (String) as Boolean
+	tell application "System Events"
+		if exists file (theFile as text) then
+			return true
+		else
+			return false
+		end if
+	end tell
+end fileExists

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.applescript
@@ -1,36 +1,53 @@
 on run argv
 	set MagicFormatPDF to 999
-	set appName to "Microsoft Excel"
 	try
 		-- get a posix file object to avoid grant access issue with 'Microsoft Office 2016',  not the same as (file documentPath) when using the 'open  ...' command
-		set tFile to (POSIX path of (item 1 of argv)) as POSIX file
-		set PDFFile to (POSIX path of (item 2 of argv)) as POSIX file
-		--tell application "Finder"
-		if fileExists(PDFFile) then
+		set inputFile to (POSIX path of (item 1 of argv)) as POSIX file
+		set outputFile to (POSIX path of (item 2 of argv)) as POSIX file
+		set formatIdentifier to (item 3 of argv) as integer
+		-- delete file if it exists, with overwrite doesn't work always
+		if fileExists(outputFile) then
 			tell application "Finder"
-			delete file PDFFile
+				delete file outputFile
 			end tell
 		end if
-		--end tell
 		tell application "Microsoft Excel"
 			set isRun to running
+			if formatIdentifier = 999 then -- PDF
+				set targetFileFormat to (PDF file format)
+			else if formatIdentifier = 51 then -- xlsx
+				set targetFileFormat to (Excel XML file format)
+			else if formatIdentifier = 54 then -- xltx
+				set targetFileFormat to (template file format)
+			else if formatIdentifier = 43 then -- xls
+				set targetFileFormat to (Excel98to2004 file format)
+			else if formatIdentifier = 60 then -- ods
+				set targetFileFormat to (XML spreadsheet file format)
+			else if formatIdentifier = 6 then -- csv
+				set targetFileFormat to (CSV Mac file format)
+			else if formatIdentifier = 46 then -- xml
+				set targetFileFormat to (XML spreadsheet file format)
+			else if formatIdentifier = 42 then --txt
+				set targetFileFormat to (text Mac file format)
+			end if
 			activate
-			open tFile
+			open inputFile
 			tell active workbook
-				alias PDFFile -- This is necessary to any script for 'Microsoft Office 2016', this avoid errors with any "save ... " command
+				alias outputFile -- This is necessary to any script for 'Microsoft Office 2016', this avoid errors with any "save ... " command
 				set wkbk1 to active workbook
-				save as active sheet filename PDFFile file format PDF file format with overwrite
+				save as active sheet filename outputFile file format targetFileFormat with overwrite
 				close saving no
 			end tell
 		end tell
 		return 2
 	on error errMsg number errorNumber
-		log ("ERROR: ")
-		log (errMsg)
-		tell application appName to quit
+		-- log ("ERROR: " & errMsg)
+		-- tell application appName to quit
 		return -6
 	end try
 end run
+
+-- function for testing if a file exists or not
 on fileExists(theFile) -- (String) as Boolean
 	tell application "System Events"
 		if exists file (theFile as text) then

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_convert.applescript
@@ -1,0 +1,24 @@
+# See http://msdn.microsoft.com/en-us/library/bb243311%28v=office.12%29.aspx
+set WdExportFormatPDF to 17
+set MagicFormatPDF to 999
+set appName to "Microsoft Excel"
+
+on fun argv
+	try 
+		tell application appName
+			open (quoted form of (item 1 of argv))
+			
+			if formatEnumeration = MagicFormatPDF then
+				save workbook as workbook (active workbook) filename (quoted form of (item 2 of argv)) file format (PDF file format) with overwrite
+			else
+			    save workbook as workbook (active workbook) filename (quoted form of (item 2 of argv)) file format ((item 3 of argv) file format) with overwrite
+			end if
+			
+			close (active workbook) saving no
+			
+			return 2
+		end tell
+	on error errMsg number errorNumber
+		return -6
+	end try
+end run	

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_shutdown.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_shutdown.applescript
@@ -1,0 +1,11 @@
+set appName to "Microsoft Excel"
+
+try 
+if application appName is running then
+    tell application appName to quit 
+else  -- excel not running, nothing to do
+	return 3 
+end if
+on error errMsg number errorNumber
+	return -6
+end try

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_shutdown.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_shutdown.applescript
@@ -1,4 +1,4 @@
-set appName to "Microsoft Word"
+set appName to "Microsoft Excel"
 
 try 
 if application appName is running then

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_start.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_start.applescript
@@ -1,4 +1,4 @@
-set appName to "Microsoft Word"
+set appName to "Microsoft Excel"
 
 try 
 if application appName is running then

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_start.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-excel/src/main/resources/excel_start.applescript
@@ -1,0 +1,14 @@
+set appName to "Microsoft Excel"
+
+try 
+if application appName is running then
+    return 3 -- everything okay, excel is already running
+else  -- excel not running, start it
+    tell application appName
+		activate 
+	end tell
+	return 3 -- everything okay, excel is now running
+end if
+on error errMsg number errorNumber
+	return -6
+end try

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-powerpoint/src/main/java/com/documents4j/conversion/msoffice/MicrosoftPowerpointBridge.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-powerpoint/src/main/java/com/documents4j/conversion/msoffice/MicrosoftPowerpointBridge.java
@@ -2,6 +2,8 @@ package com.documents4j.conversion.msoffice;
 
 import com.documents4j.api.DocumentType;
 import com.documents4j.conversion.ViableConversion;
+import com.documents4j.util.OsUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +32,7 @@ public class MicrosoftPowerpointBridge extends AbstractMicrosoftOfficeBridge {
     private static final Semaphore CONVERSION_LOCK = new Semaphore(3, true);
 
     public MicrosoftPowerpointBridge(File baseFolder, long processTimeout, TimeUnit processTimeoutUnit) {
-        super(baseFolder, processTimeout, processTimeoutUnit, MicrosoftPowerpointScript.CONVERSION);
+        super(baseFolder, processTimeout, processTimeoutUnit, MicrosoftPowerpointScript.CONVERSION, OsUtils.isMac());
         startUp();
     }
 

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-test/src/main/java/com/documents4j/conversion/msoffice/MicrosoftOfficeAssertionEngine.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-test/src/main/java/com/documents4j/conversion/msoffice/MicrosoftOfficeAssertionEngine.java
@@ -77,16 +77,16 @@ public class MicrosoftOfficeAssertionEngine {
                 .readOutput(true)
                 .exitValueAny()
                 .execute();
+        } else {
+            new ProcessExecutor()
+                    .command(Arrays.asList("cmd", "/C", String.format("\"%s\"", wordShutdownScript.getAbsolutePath())))
+                    .redirectOutput(Slf4jStream.of(LOGGER).asInfo())
+                    .redirectError(Slf4jStream.of(LOGGER).asInfo())
+                    .timeout(1L, TimeUnit.MINUTES)
+                    .exitValueAny()
+                    .execute()
+                    .getExitValue();
         }
-
-        new ProcessExecutor()
-                .command(Arrays.asList("cmd", "/C", String.format("\"%s\"", wordShutdownScript.getAbsolutePath())))
-                .redirectOutput(Slf4jStream.of(LOGGER).asInfo())
-                .redirectError(Slf4jStream.of(LOGGER).asInfo())
-                .timeout(1L, TimeUnit.MINUTES)
-                .exitValueAny()
-                .execute()
-                .getExitValue();
     }
 
     public void shutDown() {

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-test/src/main/java/com/documents4j/conversion/msoffice/MicrosoftOfficeAssertionEngine.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-test/src/main/java/com/documents4j/conversion/msoffice/MicrosoftOfficeAssertionEngine.java
@@ -1,12 +1,16 @@
 package com.documents4j.conversion.msoffice;
 
 import com.documents4j.conversion.ExternalConverterScriptResult;
+import com.documents4j.util.OsUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeroturnaround.exec.ProcessExecutor;
+import org.zeroturnaround.exec.ProcessResult;
 import org.zeroturnaround.exec.stream.slf4j.Slf4jStream;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
@@ -40,18 +44,41 @@ public class MicrosoftOfficeAssertionEngine {
 
     private int runAssertionCheckScript() throws Exception {
         assertTrue(wordAssertScript.exists());
-        return new ProcessExecutor()
-                .command(Arrays.asList("cmd", "/C", String.format("\"%s\"", wordAssertScript.getAbsolutePath())))
+        if (OsUtils.isMac()) {
+            ProcessResult res = new ProcessExecutor()
+                .command(Arrays.asList("osascript", String.format("%s", wordAssertScript.getAbsolutePath())))
                 .redirectOutput(Slf4jStream.of(LOGGER).asInfo())
                 .redirectError(Slf4jStream.of(LOGGER).asInfo())
                 .timeout(1L, TimeUnit.MINUTES)
+                .readOutput(true)
                 .exitValueAny()
-                .execute()
-                .getExitValue();
+                .execute();
+            String s = new String(res.output(), StandardCharsets.UTF_8).replaceAll("\r\n", " ").trim();
+            return Integer.parseInt(s);
+        }
+        return new ProcessExecutor()
+                    .command(Arrays.asList("cmd", "/C", String.format("\"%s\"", wordAssertScript.getAbsolutePath())))
+                    .redirectOutput(Slf4jStream.of(LOGGER).asInfo())
+                    .redirectError(Slf4jStream.of(LOGGER).asInfo())
+                    .timeout(1L, TimeUnit.MINUTES)
+                    .exitValueAny()
+                    .execute()
+                    .getExitValue();
     }
 
     public void kill() throws Exception {
         assertTrue(wordShutdownScript.exists());
+        if (OsUtils.isMac()) {
+            new ProcessExecutor()
+                .command(Arrays.asList("osascript", String.format("%s", wordShutdownScript.getAbsolutePath())))
+                .redirectOutput(Slf4jStream.of(LOGGER).asInfo())
+                .redirectError(Slf4jStream.of(LOGGER).asInfo())
+                .timeout(1L, TimeUnit.MINUTES)
+                .readOutput(true)
+                .exitValueAny()
+                .execute();
+        }
+
         new ProcessExecutor()
                 .command(Arrays.asList("cmd", "/C", String.format("\"%s\"", wordShutdownScript.getAbsolutePath())))
                 .redirectOutput(Slf4jStream.of(LOGGER).asInfo())

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/java/com/documents4j/conversion/msoffice/MicrosoftWordBridge.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/java/com/documents4j/conversion/msoffice/MicrosoftWordBridge.java
@@ -2,6 +2,8 @@ package com.documents4j.conversion.msoffice;
 
 import com.documents4j.api.DocumentType;
 import com.documents4j.conversion.ViableConversion;
+import com.documents4j.util.OsUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +39,7 @@ public class MicrosoftWordBridge extends AbstractMicrosoftOfficeBridge {
     private static final Object WORD_LOCK = new Object();
 
     public MicrosoftWordBridge(File baseFolder, long processTimeout, TimeUnit processTimeoutUnit) {
-        super(baseFolder, processTimeout, processTimeoutUnit, MicrosoftWordScript.CONVERSION);
+        super(baseFolder, processTimeout, processTimeoutUnit, MicrosoftWordScript.CONVERSION, OsUtils.isMac());
         startUp();
     }
 

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/java/com/documents4j/conversion/msoffice/MicrosoftWordScript.java
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/java/com/documents4j/conversion/msoffice/MicrosoftWordScript.java
@@ -1,6 +1,7 @@
 package com.documents4j.conversion.msoffice;
 
 import com.documents4j.throwables.FileSystemInteractionException;
+import com.documents4j.util.OsUtils;
 import com.google.common.base.MoreObjects;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
@@ -13,10 +14,10 @@ import java.util.Random;
 
 enum MicrosoftWordScript implements MicrosoftOfficeScript {
 
-    CONVERSION("/word_convert.vbs"),
-    STARTUP("/word_start.vbs"),
-    SHUTDOWN("/word_shutdown.vbs"),
-    ASSERTION("/word_assert.vbs");
+    CONVERSION("/word_convert" + (OsUtils.isWindows() ? ".vbs" : (OsUtils.isMac() ? ".applescript" : ".sh"))),
+    STARTUP("/word_start" + (OsUtils.isWindows() ? ".vbs" : (OsUtils.isMac() ? ".applescript" : ".sh"))),
+    SHUTDOWN("/word_shutdown" + (OsUtils.isWindows() ? ".vbs" : (OsUtils.isMac() ? ".applescript" : ".sh"))),
+    ASSERTION("/word_assert" + (OsUtils.isWindows() ? ".vbs" : (OsUtils.isMac() ? ".applescript" : ".sh")));
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MicrosoftWordBridge.class);
     private static final Random RANDOM = new Random();

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_assert.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_assert.applescript
@@ -4,10 +4,7 @@ try
 if application appName is running then
     return 3 -- everything okay, excel is already running
 else  -- excel not running, start it
-    tell application appName
-		activate 
-	end tell
-	return 3 -- everything okay, excel is now running
+	return -6 
 end if
 on error errMsg number errorNumber
 	return -6

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_convert.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_convert.applescript
@@ -1,0 +1,61 @@
+on run argv
+	set MagicFormatPDF to 999
+	try
+		-- get a posix file object to avoid grant access issue with 'Microsoft Office 2016',  not the same as (file documentPath) when using the 'open  ...' command
+		set inputFile to (POSIX path of (item 1 of argv)) as POSIX file
+		set outputFile to (POSIX path of (item 2 of argv)) as POSIX file
+		set formatIdentifier to (item 3 of argv) as integer
+		-- delete file if it exists, with overwrite doesn't work always
+		if fileExists(outputFile) then
+			tell application "Finder"
+				delete file outputFile
+			end tell
+		end if
+		tell application "Microsoft Word"
+			set isRun to running
+			if formatIdentifier = 999 then -- PDF
+				set targetFileFormat to (format PDF)
+			else if formatIdentifier = 17 then -- PDF
+				set targetFileFormat to (format PDF)
+			else if formatIdentifier = 12 then -- docx
+				set targetFileFormat to (format document)
+			else if formatIdentifier = 0 then -- doc
+				set targetFileFormat to (format document97)
+			else if formatIdentifier = 6 then -- rtf
+				set targetFileFormat to (format rtf)
+			else if formatIdentifier = 9 then -- mhtml
+				set targetFileFormat to (format web archive)
+			else if formatIdentifier = 10 then -- html
+				set targetFileFormat to (format filtered HTML)
+			else if formatIdentifier = 11 then -- xml
+				set targetFileFormat to (format xml)
+			else if formatIdentifier = 7 then --txt
+				set targetFileFormat to (format text)
+			end if
+			activate
+			open inputFile
+			tell active document
+				alias outputFile -- This is necessary to any script for 'Microsoft Office 2016', this avoid errors with any "save ... " command
+				set wkbk1 to active document
+				save as document file name outputFile file format targetFileFormat with overwrite
+				close saving no
+			end tell
+		end tell
+		return 2
+	on error errMsg number errorNumber
+		log ("ERROR: " & errMsg)
+		-- tell application appName to quit
+		return -6
+	end try
+end run
+
+-- function for testing if a file exists or not
+on fileExists(theFile) -- (String) as Boolean
+	tell application "System Events"
+		if exists file (theFile as text) then
+			return true
+		else
+			return false
+		end if
+	end tell
+end fileExists

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_shutdown.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_shutdown.applescript
@@ -1,4 +1,4 @@
-set appName to "Microsoft Word"
+set appName to "Microsoft Excel"
 
 try 
 if application appName is running then

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_shutdown.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_shutdown.applescript
@@ -1,4 +1,4 @@
-set appName to "Microsoft Excel"
+set appName to "Microsoft Word"
 
 try 
 if application appName is running then

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_start.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_start.applescript
@@ -1,4 +1,4 @@
-set appName to "Microsoft Word"
+set appName to "Microsoft Excel"
 
 try 
 if application appName is running then

--- a/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_start.applescript
+++ b/documents4j-transformer-msoffice/documents4j-transformer-msoffice-word/src/main/resources/word_start.applescript
@@ -1,4 +1,4 @@
-set appName to "Microsoft Excel"
+set appName to "Microsoft Word"
 
 try 
 if application appName is running then

--- a/documents4j-util-all/src/main/java/com/documents4j/util/OsUtils.java
+++ b/documents4j-util-all/src/main/java/com/documents4j/util/OsUtils.java
@@ -1,0 +1,27 @@
+package com.documents4j.util;
+
+public class OsUtils {
+
+    private static String myOS = System.getProperty("os.name").toLowerCase();
+
+    private OsUtils() {
+        /* empty, but suppress visibility outside of package */
+    }
+
+    public static boolean isWindows() {
+        return (myOS.indexOf("win") >= 0);
+    }
+
+    public static boolean isMac() {
+        return (myOS.indexOf("mac") >= 0);
+    }
+
+    public static boolean isUnix() {
+        return (myOS.indexOf("nix") >= 0 || myOS.indexOf("nux") >= 0 || myOS.indexOf("aix") > 0);
+    }
+
+    public static boolean isSolaris() {
+        return (myOS.indexOf("sunos") >= 0);
+    }
+
+}

--- a/documents4j-util-all/src/main/java/com/documents4j/util/OsUtils.java
+++ b/documents4j-util-all/src/main/java/com/documents4j/util/OsUtils.java
@@ -2,7 +2,7 @@ package com.documents4j.util;
 
 public class OsUtils {
 
-    private static String myOS = System.getProperty("os.name").toLowerCase();
+    private static final String myOS = System.getProperty("os.name").toLowerCase();
 
     private OsUtils() {
         /* empty, but suppress visibility outside of package */

--- a/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/AbstractExternalConverter.java
+++ b/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/AbstractExternalConverter.java
@@ -1,6 +1,8 @@
 package com.documents4j.conversion;
 
 import com.documents4j.throwables.ConverterAccessException;
+import com.documents4j.util.OsUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeroturnaround.exec.ProcessExecutor;
@@ -68,8 +70,13 @@ public abstract class AbstractExternalConverter implements IExternalConverter {
             // would typically be triggered from a shut down hook. Therefore, the shut down process
             // should never be killed during JVM shut down. In order to avoid an incomplete start up
             // procedure, start up processes will never be killed either.
-            String[] command = {"cmd", "/S", "/C", doubleQuote(script.getAbsolutePath())};
+            String[] command = null;
 
+            if (OsUtils.isWindows()) {
+                command = new String[]{"cmd", "/S", "/C", doubleQuote(script.getAbsolutePath())};
+            } else if (OsUtils.isMac()) {
+                command = new String[]{"osascript", doubleQuote(script.getAbsolutePath())};
+            }
             int exitCode = makePresetProcessExecutor()
                     .command(command)
                     .execute().getExitValue();

--- a/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/AbstractExternalConverter.java
+++ b/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/AbstractExternalConverter.java
@@ -75,7 +75,7 @@ public abstract class AbstractExternalConverter implements IExternalConverter {
             if (OsUtils.isWindows()) {
                 command = new String[]{"cmd", "/S", "/C", doubleQuote(script.getAbsolutePath())};
             } else if (OsUtils.isMac()) {
-                command = new String[]{"osascript", doubleQuote(script.getAbsolutePath())};
+                command = new String[]{"/usr/bin/osascript", script.getAbsolutePath()};
             }
             int exitCode = makePresetProcessExecutor()
                     .command(command)

--- a/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/AbstractExternalConverter.java
+++ b/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/AbstractExternalConverter.java
@@ -3,12 +3,9 @@ package com.documents4j.conversion;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.ToIntFunction;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeroturnaround.exec.ProcessExecutor;
@@ -62,7 +59,7 @@ public abstract class AbstractExternalConverter implements IExternalConverter {
         return makePresetProcessExecutor(Slf4jStream.of(logger).asInfo());
     }
 
-    protected ProcessExecutor makePresetProcessExecutor(OutputStream outputStream) { 
+    protected ProcessExecutor makePresetProcessExecutor(OutputStream outputStream) {
         return new ProcessExecutor()
                 .redirectOutput(outputStream)
                 .redirectError(Slf4jStream.of(logger).asInfo())
@@ -89,8 +86,8 @@ public abstract class AbstractExternalConverter implements IExternalConverter {
                                .execute().getExitValue();
             } else if (OsUtils.isMac()) {
                 command = new String[]{"/usr/bin/osascript", script.getAbsolutePath()};
-                ProcessResult res = makePresetProcessExecutor().command(command).execute(); 
-                ToIntFunction<ProcessResult> extractor = ( processResult -> Integer.parseInt(new String(processResult.output(), StandardCharsets.UTF_8).replaceAll("\\n", "")) );
+                ProcessResult res = makePresetProcessExecutor().command(command).execute();
+                //ToIntFunction<ProcessResult> extractor = ( processResult -> Integer.parseInt(new String(processResult.output(), StandardCharsets.UTF_8).replaceAll("\\n", "")) );
                 //exitCode = extractor.applyAsInt(res);
                 exitCode = res.getExitValue();
             }

--- a/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/AbstractExternalConverter.java
+++ b/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/AbstractExternalConverter.java
@@ -3,9 +3,12 @@ package com.documents4j.conversion;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.ToIntFunction;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeroturnaround.exec.ProcessExecutor;
@@ -87,9 +90,8 @@ public abstract class AbstractExternalConverter implements IExternalConverter {
             } else if (OsUtils.isMac()) {
                 command = new String[]{"/usr/bin/osascript", script.getAbsolutePath()};
                 ProcessResult res = makePresetProcessExecutor().command(command).execute();
-                //ToIntFunction<ProcessResult> extractor = ( processResult -> Integer.parseInt(new String(processResult.output(), StandardCharsets.UTF_8).replaceAll("\\n", "")) );
-                //exitCode = extractor.applyAsInt(res);
-                exitCode = res.getExitValue();
+                ToIntFunction<ProcessResult> extractor = ( processResult -> Integer.parseInt(new String(processResult.output(), StandardCharsets.UTF_8).replaceAll("\\n", "")) );
+                exitCode = extractor.applyAsInt(res);
             }
             logger.trace("Got exitcode {} for command {}", exitCode, Arrays.toString(command));
             return exitCode;

--- a/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/ProcessFutureWrapper.java
+++ b/documents4j-util-transformer-process/src/main/java/com/documents4j/conversion/ProcessFutureWrapper.java
@@ -1,15 +1,15 @@
 package com.documents4j.conversion;
 
-import com.documents4j.throwables.ConverterException;
-import org.zeroturnaround.exec.ProcessResult;
-import org.zeroturnaround.exec.StartedProcess;
-
-import java.io.OutputStream;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.ToIntFunction;
+
+import org.zeroturnaround.exec.ProcessResult;
+import org.zeroturnaround.exec.StartedProcess;
+
+import com.documents4j.throwables.ConverterException;
 
 public class ProcessFutureWrapper implements Future<Boolean> {
 


### PR DESCRIPTION
Here my changes for Issue #126, Support for MacOS. 

I've added .applescripts for Word and Excel. These work on the command line. I've also added the code for execution in documents4j, plus retrieval of the return value as you proposed.  

I still have problems running the test-cases (on windows and mac), however in my own application the conversion works as intended. 

