### PR TITLE
Updated jersey dependencies

### DIFF
--- a/documents4j-client/src/main/java/com/documents4j/job/RemoteConversionContext.java
+++ b/documents4j-client/src/main/java/com/documents4j/job/RemoteConversionContext.java
@@ -1,6 +1,6 @@
 package com.documents4j.job;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.concurrent.Future;
 
 class RemoteConversionContext implements IConversionContext {

--- a/documents4j-client/src/main/java/com/documents4j/job/RemoteConverter.java
+++ b/documents4j-client/src/main/java/com/documents4j/job/RemoteConverter.java
@@ -18,11 +18,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Feature;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.MediaType;
 import java.io.File;
 import java.net.URI;
 import java.util.Map;

--- a/documents4j-client/src/main/java/com/documents4j/job/RemoteFutureWrappingPriorityFuture.java
+++ b/documents4j-client/src/main/java/com/documents4j/job/RemoteFutureWrappingPriorityFuture.java
@@ -6,9 +6,9 @@ import com.documents4j.api.IInputStreamSource;
 import com.documents4j.ws.ConverterNetworkProtocol;
 import com.google.common.base.MoreObjects;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/documents4j-client/src/main/java/com/documents4j/job/WebserviceRequestFutureWrapper.java
+++ b/documents4j-client/src/main/java/com/documents4j/job/WebserviceRequestFutureWrapper.java
@@ -4,7 +4,7 @@ import com.documents4j.throwables.ConverterException;
 import com.documents4j.ws.ConverterNetworkProtocol;
 import com.google.common.base.MoreObjects;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;

--- a/documents4j-client/src/test/java/com/documents4j/job/RemoteConverterTestDelegate.java
+++ b/documents4j-client/src/test/java/com/documents4j/job/RemoteConverterTestDelegate.java
@@ -6,7 +6,7 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.spi.TestContainerException;
 
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.core.Application;
 import java.net.URI;
 
 import static org.junit.Assert.assertEquals;

--- a/documents4j-client/src/test/java/com/documents4j/ws/endpoint/MockWebApplication.java
+++ b/documents4j-client/src/test/java/com/documents4j/ws/endpoint/MockWebApplication.java
@@ -4,14 +4,14 @@ import com.documents4j.ws.ConverterNetworkProtocol;
 import org.glassfish.jersey.message.GZipEncoder;
 import org.glassfish.jersey.server.filter.EncodingFilter;
 
-import javax.annotation.Priority;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.ext.Provider;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.util.*;
 

--- a/documents4j-client/src/test/java/com/documents4j/ws/endpoint/MockWebService.java
+++ b/documents4j-client/src/test/java/com/documents4j/ws/endpoint/MockWebService.java
@@ -7,10 +7,10 @@ import com.documents4j.ws.ConverterNetworkProtocol;
 import com.documents4j.ws.ConverterServerInformation;
 import com.google.common.base.Charsets;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
 

--- a/documents4j-client/src/test/java/com/documents4j/ws/endpoint/MockWebServiceCallback.java
+++ b/documents4j-client/src/test/java/com/documents4j/ws/endpoint/MockWebServiceCallback.java
@@ -7,7 +7,7 @@ import com.documents4j.throwables.ConversionInputException;
 import com.documents4j.throwables.ConverterException;
 import com.documents4j.ws.ConverterNetworkProtocol;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 class MockWebServiceCallback implements IInputStreamConsumer {

--- a/documents4j-server-standalone/pom.xml
+++ b/documents4j-server-standalone/pom.xml
@@ -79,12 +79,6 @@
             <artifactId>jul-to-slf4j</artifactId>
         </dependency>
 
-        <!-- Add dependency removed in Java 11 -->
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-
         <!-- Testing dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/documents4j-server-standalone/src/main/java/com/documents4j/server/auth/AuthFilter.java
+++ b/documents4j-server-standalone/src/main/java/com/documents4j/server/auth/AuthFilter.java
@@ -1,8 +1,8 @@
 package com.documents4j.server.auth;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Response;
 import java.util.Base64;
 import java.util.Set;
 

--- a/documents4j-server-standalone/src/main/java/com/documents4j/ws/application/StandaloneWebConverterConfiguration.java
+++ b/documents4j-server-standalone/src/main/java/com/documents4j/ws/application/StandaloneWebConverterConfiguration.java
@@ -1,6 +1,7 @@
 package com.documents4j.ws.application;
 
-import com.documents4j.api.IConverter;
+import com.documents4j.api
+        .IConverter;
 import com.documents4j.conversion.IExternalConverter;
 import com.documents4j.job.LocalConverter;
 import org.glassfish.jersey.server.spi.Container;
@@ -8,7 +9,7 @@ import org.glassfish.jersey.server.spi.ContainerLifecycleListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.Provider;
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/documents4j-server-standalone/src/test/java/com/documents4j/server/auth/AuthFilterTest.java
+++ b/documents4j-server-standalone/src/test/java/com/documents4j/server/auth/AuthFilterTest.java
@@ -3,8 +3,8 @@ package com.documents4j.server.auth;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.UriInfo;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.UriInfo;
 import java.util.Base64;
 import java.util.Collections;
 

--- a/documents4j-server/pom.xml
+++ b/documents4j-server/pom.xml
@@ -48,14 +48,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/documents4j-server/src/main/java/com/documents4j/ws/application/WebConverterApplication.java
+++ b/documents4j-server/src/main/java/com/documents4j/ws/application/WebConverterApplication.java
@@ -5,7 +5,7 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.message.GZipEncoder;
 import org.glassfish.jersey.server.filter.EncodingFilter;
 
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.core.Application;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;

--- a/documents4j-server/src/main/java/com/documents4j/ws/endpoint/AsynchronousConversionResponse.java
+++ b/documents4j-server/src/main/java/com/documents4j/ws/endpoint/AsynchronousConversionResponse.java
@@ -6,9 +6,9 @@ import com.documents4j.ws.ConverterNetworkProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.TimeoutHandler;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.TimeoutHandler;
+import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 

--- a/documents4j-server/src/main/java/com/documents4j/ws/endpoint/ConverterResource.java
+++ b/documents4j-server/src/main/java/com/documents4j/ws/endpoint/ConverterResource.java
@@ -6,13 +6,13 @@ import com.documents4j.ws.ConverterNetworkProtocol;
 import com.documents4j.ws.ConverterServerInformation;
 import com.documents4j.ws.application.IWebConverterConfiguration;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.Suspended;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 @Path(ConverterNetworkProtocol.RESOURCE_PATH)

--- a/documents4j-server/src/main/java/com/documents4j/ws/endpoint/MonitoringHealthCreateDocumentResource.java
+++ b/documents4j-server/src/main/java/com/documents4j/ws/endpoint/MonitoringHealthCreateDocumentResource.java
@@ -6,10 +6,10 @@ import com.documents4j.ws.application.IWebConverterConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 

--- a/documents4j-server/src/main/java/com/documents4j/ws/endpoint/MonitoringHealthResource.java
+++ b/documents4j-server/src/main/java/com/documents4j/ws/endpoint/MonitoringHealthResource.java
@@ -4,10 +4,10 @@ import com.documents4j.ws.application.IWebConverterConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 /**
  * Provides an endpoint that returns it's health in form of HTTP status codes so that it can

--- a/documents4j-server/src/main/java/com/documents4j/ws/endpoint/MonitoringRunningResource.java
+++ b/documents4j-server/src/main/java/com/documents4j/ws/endpoint/MonitoringRunningResource.java
@@ -1,8 +1,8 @@
 package com.documents4j.ws.endpoint;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 /**
  * Provides an endpoint that is not protected and returns always 200 OK if the service is running.

--- a/documents4j-server/src/test/java/com/documents4j/ws/endpoint/AbstractEncodingJerseyTest.java
+++ b/documents4j-server/src/test/java/com/documents4j/ws/endpoint/AbstractEncodingJerseyTest.java
@@ -7,13 +7,13 @@ import org.glassfish.jersey.client.filter.EncodingFeature;
 import org.glassfish.jersey.message.GZipEncoder;
 import org.glassfish.jersey.test.JerseyTest;
 
-import javax.annotation.Priority;
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientRequestFilter;
-import javax.ws.rs.client.ClientResponseContext;
-import javax.ws.rs.client.ClientResponseFilter;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.ext.Provider;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.client.ClientResponseContext;
+import jakarta.ws.rs.client.ClientResponseFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.util.List;
 

--- a/documents4j-server/src/test/java/com/documents4j/ws/endpoint/InoperativeConverterResourceTest.java
+++ b/documents4j-server/src/test/java/com/documents4j/ws/endpoint/InoperativeConverterResourceTest.java
@@ -8,10 +8,10 @@ import com.documents4j.ws.application.WebConverterTestConfiguration;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Test;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;

--- a/documents4j-server/src/test/java/com/documents4j/ws/endpoint/MonitoringHealthCreateDocumentResourceTest.java
+++ b/documents4j-server/src/test/java/com/documents4j/ws/endpoint/MonitoringHealthCreateDocumentResourceTest.java
@@ -5,7 +5,7 @@ import com.documents4j.job.MockConversion;
 import com.documents4j.ws.application.WebConverterTestConfiguration;
 import org.junit.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;

--- a/documents4j-server/src/test/java/com/documents4j/ws/endpoint/OperationalConverterResourceTest.java
+++ b/documents4j-server/src/test/java/com/documents4j/ws/endpoint/OperationalConverterResourceTest.java
@@ -10,10 +10,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;

--- a/documents4j-util-conversion/pom.xml
+++ b/documents4j-util-conversion/pom.xml
@@ -30,12 +30,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
-        <!-- Add dependency removed in Java 11 -->
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-
         <!-- Testing dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/documents4j-util-ws/pom.xml
+++ b/documents4j-util-ws/pom.xml
@@ -25,18 +25,11 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Add dependency removed in Java 11 -->
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-
         <!-- External dependencies -->
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+            </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -45,18 +38,18 @@
 
         <!-- Add dependency removed in Java 11 -->
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
-        
+
+        <!-- Runtime, com.sun.xml.bind module -->
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-jaxb</artifactId>
         </dependency>
-        
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/documents4j-util-ws/src/main/java/com/documents4j/ws/AdaptedDocumentType.java
+++ b/documents4j-util-ws/src/main/java/com/documents4j/ws/AdaptedDocumentType.java
@@ -2,7 +2,7 @@ package com.documents4j.ws;
 
 import com.documents4j.api.DocumentType;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 public class AdaptedDocumentType {
 

--- a/documents4j-util-ws/src/main/java/com/documents4j/ws/ConverterNetworkProtocol.java
+++ b/documents4j-util-ws/src/main/java/com/documents4j/ws/ConverterNetworkProtocol.java
@@ -6,7 +6,7 @@ import com.documents4j.util.Reaction;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 /**
  * This class is a non-instantiable carrier for values that are used in network communication between a

--- a/documents4j-util-ws/src/main/java/com/documents4j/ws/ConverterServerInformation.java
+++ b/documents4j-util-ws/src/main/java/com/documents4j/ws/ConverterServerInformation.java
@@ -2,9 +2,9 @@ package com.documents4j.ws;
 
 import com.documents4j.api.DocumentType;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Map;
 import java.util.Set;
 

--- a/documents4j-util-ws/src/main/java/com/documents4j/ws/DocumentTypeAdapter.java
+++ b/documents4j-util-ws/src/main/java/com/documents4j/ws/DocumentTypeAdapter.java
@@ -2,7 +2,7 @@ package com.documents4j.ws;
 
 import com.documents4j.api.DocumentType;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 public class DocumentTypeAdapter extends XmlAdapter<AdaptedDocumentType, DocumentType> {
 

--- a/documents4j-util-ws/src/main/java/com/documents4j/ws/DocumentTypeMapAdapter.java
+++ b/documents4j-util-ws/src/main/java/com/documents4j/ws/DocumentTypeMapAdapter.java
@@ -2,9 +2,9 @@ package com.documents4j.ws;
 
 import com.documents4j.api.DocumentType;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/documents4j-util-ws/src/test/java/com/documents4j/ws/MarshallingTest.java
+++ b/documents4j-util-ws/src/test/java/com/documents4j/ws/MarshallingTest.java
@@ -3,9 +3,9 @@ package com.documents4j.ws;
 import com.documents4j.api.DocumentType;
 import org.junit.Test;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.*;

--- a/pom.xml
+++ b/pom.xml
@@ -82,13 +82,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <shaded.classifier>shaded</shaded.classifier>
-        <version.javax.rs>2.0.1</version.javax.rs>
+        <version.jakarta.rs>3.0.0</version.jakarta.rs>
         <version.javax.servlet>3.0.1</version.javax.servlet>
-        <version.javax.inject>1</version.javax.inject>
-        <version.javax.annotation>1.2</version.javax.annotation>
-        <version.javax.activation>1.1.1</version.javax.activation>
-        <version.javax.jaxb>2.3.0</version.javax.jaxb>
-        <version.jersey>2.29</version.jersey>
+        <version.jakarta.inject>2.0.0</version.jakarta.inject>
+        <version.jakarta.bind>3.0.0</version.jakarta.bind>
+        <version.glashfish.jaxb>3.0.2</version.glashfish.jaxb>
+        <version.jersey>3.0.2</version.jersey>
         <version.guava>30.0-jre</version.guava>
         <version.zt-exec>1.11</version.zt-exec>
         <version.jopt-simple>5.0.4</version.jopt-simple>
@@ -213,9 +212,9 @@
 
             <!-- Java extensions -->
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
-                <version>${version.javax.rs}</version>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${version.jakarta.rs}</version>
             </dependency>
 
             <dependency>
@@ -225,39 +224,21 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>${version.javax.inject}</version>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${version.jakarta.inject}</version>
             </dependency>
 
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>${version.javax.annotation}</version>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${version.jakarta.bind}</version>
             </dependency>
 
             <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>${version.javax.activation}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${version.javax.jaxb}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-core</artifactId>
-                <version>${version.javax.jaxb}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${version.javax.jaxb}</version>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${version.glashfish.jaxb}</version>
             </dependency>
 
             <!-- Testing / Logging -->


### PR DESCRIPTION
Updated org.glassfish.jersey dependencies to work with the last version of Springboot. Changed javax namespace to the new jakarta namespace