### PR TITLE
Changed duplicated short key command

### DIFF
--- a/documents4j-util-standalone/src/main/java/com/documents4j/standalone/CommandDescription.java
+++ b/documents4j-util-standalone/src/main/java/com/documents4j/standalone/CommandDescription.java
@@ -55,7 +55,7 @@ public class CommandDescription {
             "is currently very busy.";
 
     public static final String ARGUMENT_LONG_SSL = "ssl";
-    public static final String ARGUMENT_SHORT_SSL = "E";
+    public static final String ARGUMENT_SHORT_SSL = "K";
     public static final String DESCRIPTION_CONTEXT_SSL = "Registers the JVM's default SSL context for encryption of conversions.";
 
     public static final String ARGUMENT_LONG_AUTH = "auth";


### PR DESCRIPTION
https://github.com/documents4j/documents4j/issues/151 I changed the short key of the `--ssl` command to E because that key was also used for the `--enable` command