### PR TITLE
Configure logging using Logback's mechanism

### DIFF
--- a/documents4j-local-demo/src/main/java/com/documents4j/demo/DemoApplication.java
+++ b/documents4j-local-demo/src/main/java/com/documents4j/demo/DemoApplication.java
@@ -4,7 +4,7 @@ import com.documents4j.api.IConverter;
 import com.documents4j.job.LocalConverter;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.protocol.http.WebApplication;
-import org.slf4j.impl.SimpleLogger;
+import org.slf4j.simple.SimpleLogger;
 
 import java.io.File;
 import java.io.IOException;

--- a/documents4j-server-standalone/pom.xml
+++ b/documents4j-server-standalone/pom.xml
@@ -75,11 +75,6 @@
         </dependency>
 
         <dependency>
-            <groupId>net.logstash.logback</groupId>
-            <artifactId>logstash-logback-encoder</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
         </dependency>

--- a/documents4j-server-standalone/pom.xml
+++ b/documents4j-server-standalone/pom.xml
@@ -75,6 +75,11 @@
         </dependency>
 
         <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
         </dependency>

--- a/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
+++ b/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
@@ -447,12 +447,12 @@ public class StandaloneServer {
     }
 
     private static OptionSpec<?> makeJsonLogSpec(OptionParser optionParser) {
-        return optionParser.acceptsAll(
-                Arrays.asList(
+        return optionParser
+                .acceptsAll(Arrays.asList(
                         CommandDescription.ARGUMENT_LONG_JSON_LOG,
                         CommandDescription.ARGUMENT_SHORT_JSON_LOG),
-                CommandDescription.DESCRIPTION_ARGUMENT_JSON_LOG
-        );
+                        CommandDescription.DESCRIPTION_ARGUMENT_JSON_LOG
+                );
     }
 
     private static ArgumentAcceptingOptionSpec<Class<? extends IExternalConverter>> makeConverterDisabledSpec(OptionParser optionParser) {

--- a/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
+++ b/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
@@ -326,8 +326,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<File> makeBaseFolderSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_BASE_FOLDER,
-                                CommandDescription.ARGUMENT_SHORT_BASE_FOLDER),
+                        CommandDescription.ARGUMENT_LONG_BASE_FOLDER,
+                        CommandDescription.ARGUMENT_SHORT_BASE_FOLDER),
                         CommandDescription.DESCRIPTION_CONTEXT_BASE_FOLDER
                 )
                 .withRequiredArg()
@@ -339,8 +339,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Integer> makeCorePoolSizeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_CORE_POOL_SIZE,
-                                CommandDescription.ARGUMENT_SHORT_CORE_POOL_SIZE),
+                        CommandDescription.ARGUMENT_LONG_CORE_POOL_SIZE,
+                        CommandDescription.ARGUMENT_SHORT_CORE_POOL_SIZE),
                         CommandDescription.DESCRIPTION_CONTEXT_CORE_POOL_SIZE
                 )
                 .withRequiredArg()
@@ -352,8 +352,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Integer> makeFallbackPoolSizeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_MAXIMUM_POOL_SIZE,
-                                CommandDescription.ARGUMENT_SHORT_MAXIMUM_POOL_SIZE),
+                        CommandDescription.ARGUMENT_LONG_MAXIMUM_POOL_SIZE,
+                        CommandDescription.ARGUMENT_SHORT_MAXIMUM_POOL_SIZE),
                         CommandDescription.DESCRIPTION_CONTEXT_MAXIMUM_POOL_SIZE
                 )
                 .withRequiredArg()
@@ -365,8 +365,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Long> makeKeepAliveTimeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_KEEP_ALIVE_TIME,
-                                CommandDescription.ARGUMENT_SHORT_KEEP_ALIVE_TIME),
+                        CommandDescription.ARGUMENT_LONG_KEEP_ALIVE_TIME,
+                        CommandDescription.ARGUMENT_SHORT_KEEP_ALIVE_TIME),
                         CommandDescription.DESCRIPTION_CONTEXT_KEEP_ALIVE_TIME
                 )
                 .withRequiredArg()
@@ -378,8 +378,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Long> makeProcessTimeoutSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_PROCESS_TIME_OUT,
-                                CommandDescription.ARGUMENT_SHORT_PROCESS_TIME_OUT),
+                        CommandDescription.ARGUMENT_LONG_PROCESS_TIME_OUT,
+                        CommandDescription.ARGUMENT_SHORT_PROCESS_TIME_OUT),
                         CommandDescription.DESCRIPTION_CONTEXT_PROCESS_TIME_OUT
                 )
                 .withRequiredArg()
@@ -391,8 +391,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Long> makeRequestTimeoutSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_REQUEST_TIMEOUT,
-                                CommandDescription.ARGUMENT_SHORT_REQUEST_TIMEOUT),
+                        CommandDescription.ARGUMENT_LONG_REQUEST_TIMEOUT,
+                        CommandDescription.ARGUMENT_SHORT_REQUEST_TIMEOUT),
                         CommandDescription.DESCRIPTION_CONTEXT_REQUEST_TIMEOUT
                 )
                 .withRequiredArg()
@@ -404,8 +404,8 @@ public class StandaloneServer {
     private static OptionSpec<?> makeSslSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_SSL,
-                                CommandDescription.ARGUMENT_SHORT_SSL),
+                        CommandDescription.ARGUMENT_LONG_SSL,
+                        CommandDescription.ARGUMENT_SHORT_SSL),
                         CommandDescription.DESCRIPTION_CONTEXT_SSL
                 );
     }
@@ -413,8 +413,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<String> makeAuthSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_AUTH,
-                                CommandDescription.ARGUMENT_SHORT_AUTH),
+                        CommandDescription.ARGUMENT_LONG_AUTH,
+                        CommandDescription.ARGUMENT_SHORT_AUTH),
                         CommandDescription.DESCRIPTION_CONTEXT_AUTH
                 ).withRequiredArg()
                 .ofType(String.class);
@@ -423,8 +423,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<File> makeLogFileSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_LOG_TO_FILE,
-                                CommandDescription.ARGUMENT_SHORT_LOG_TO_FILE),
+                        CommandDescription.ARGUMENT_LONG_LOG_TO_FILE,
+                        CommandDescription.ARGUMENT_SHORT_LOG_TO_FILE),
                         CommandDescription.DESCRIPTION_CONTEXT_LOG_TO_FILE
                 )
                 .withRequiredArg()
@@ -436,8 +436,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Level> makeLogLevelSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_LOG_LEVEL,
-                                CommandDescription.ARGUMENT_SHORT_LOG_LEVEL),
+                        CommandDescription.ARGUMENT_LONG_LOG_LEVEL,
+                        CommandDescription.ARGUMENT_SHORT_LOG_LEVEL),
                         CommandDescription.DESCRIPTION_CONTEXT_LOG_LEVEL
                 )
                 .withRequiredArg()
@@ -458,8 +458,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Class<? extends IExternalConverter>> makeConverterDisabledSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_DISABLED_CONVERTER,
-                                CommandDescription.ARGUMENT_SHORT_DISABLED_CONVERTER),
+                        CommandDescription.ARGUMENT_LONG_DISABLED_CONVERTER,
+                        CommandDescription.ARGUMENT_SHORT_DISABLED_CONVERTER),
                         CommandDescription.DESCRIPTION_CONTEXT_DISABLED_CONVERTER
                 )
                 .withRequiredArg()
@@ -470,8 +470,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Class<? extends IExternalConverter>> makeConverterEnabledSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_ENABLED_CONVERTER,
-                                CommandDescription.ARGUMENT_SHORT_ENABLED_CONVERTER),
+                        CommandDescription.ARGUMENT_LONG_ENABLED_CONVERTER,
+                        CommandDescription.ARGUMENT_SHORT_ENABLED_CONVERTER),
                         CommandDescription.DESCRIPTION_CONTEXT_ENABLED_CONVERTER
                 )
                 .withRequiredArg()
@@ -486,8 +486,8 @@ public class StandaloneServer {
     private static OptionSpec<Void> makeHelpSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_HELP,
-                                CommandDescription.ARGUMENT_SHORT_HELP),
+                        CommandDescription.ARGUMENT_LONG_HELP,
+                        CommandDescription.ARGUMENT_SHORT_HELP),
                         CommandDescription.DESCRIPTION_CONTEXT_HELP
                 )
                 .forHelp();
@@ -496,8 +496,8 @@ public class StandaloneServer {
     private static OptionSpec<Void> makeServiceModeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_SERVICE_MODE,
-                                CommandDescription.ARGUMENT_SHORT_SERVICE_MODE),
+                        CommandDescription.ARGUMENT_LONG_SERVICE_MODE,
+                        CommandDescription.ARGUMENT_SHORT_SERVICE_MODE),
                         CommandDescription.DESCRIPTION_CONTEXT_SERVICE_MODE
                 );
     }

--- a/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
+++ b/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
@@ -135,7 +135,7 @@ public class StandaloneServer {
         checkArgument(requestTimeout >= 0L, "The request timeout timeout must not be negative");
 
         Level level = logLevelSpec.value(optionSet);
-        LOG.info("Logging: The log level is set to " + level);
+        LOG.info("Logging: The log level is set to {}", level);
 
         ConverterServerBuilder builder = ConverterServerBuilder.builder()
                 .baseUri(baseUri)
@@ -153,7 +153,7 @@ public class StandaloneServer {
             try {
                 builder = builder.sslContext(SSLContext.getDefault());
             } catch (NoSuchAlgorithmException e) {
-                LOG.info("Could not access default SSL context: " + e.getMessage());
+                LOG.info("Could not access default SSL context: {}", e.getMessage());
                 System.exit(-1);
             }
         }

--- a/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
+++ b/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
@@ -1,24 +1,11 @@
 package com.documents4j.standalone;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.classic.jul.LevelChangePropagator;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.ConsoleAppender;
-import ch.qos.logback.core.Context;
-import ch.qos.logback.core.OutputStreamAppender;
-import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
-import ch.qos.logback.core.rolling.RollingFileAppender;
-import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
-import ch.qos.logback.core.util.FileSize;
 import com.documents4j.builder.ConverterServerBuilder;
 import com.documents4j.conversion.IExternalConverter;
 import com.documents4j.job.LocalConverter;
 import com.documents4j.ws.application.IWebConverterConfiguration;
 import joptsimple.*;
-import net.logstash.logback.composite.loggingevent.*;
-import net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +25,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * Entry point for a command-line invoked standalone conversion server.
  */
 public class StandaloneServer {
+    private static final Logger LOG = LoggerFactory.getLogger(StandaloneServer.class);
 
     private StandaloneServer() {
         throw new UnsupportedOperationException();
@@ -51,29 +39,31 @@ public class StandaloneServer {
      */
     public static void main(String[] args) {
         try {
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
+            SLF4JBridgeHandler.install();
+
             ConverterServerBuilder builder = asBuilder(args);
             HttpServer httpServer = builder.build();
-            Logger logger = LoggerFactory.getLogger(StandaloneServer.class);
             try {
-                sayHello(builder, logger);
+                sayHello(builder);
                 if (builder.isServiceMode()) {
-                    System.out.println("The documents4j server is up and running in service mode and will not terminate until process interruption.");
+                    LOG.info("The documents4j server is up and running in service mode and will not terminate until process interruption.");
                     try {
                         Thread.currentThread().join();
                     } catch (InterruptedException ignored) {
-                        System.out.println("Received interruption signal which indicates server termination.");
+                        LOG.info("Received interruption signal which indicates server termination.");
                     }
                 } else {
-                    System.out.println("The documents4j server is up and running. Hit the enter key to shut it down...");
+                    LOG.info("The documents4j server is up and running. Hit the enter key to shut it down...");
                     if (System.in.read() == -1) {
-                        System.out.println("Console read terminated without receiving user input");
+                        LOG.info("Console read terminated without receiving user input");
                     }
                 }
-                sayGoodbye(builder, logger);
+                sayGoodbye(builder);
             } finally {
                 httpServer.shutdownNow();
             }
-            System.out.println("Shut down successful. Goodbye!");
+            LOG.info("Shut down successful. Goodbye!");
         } catch (Exception e) {
             LoggerFactory.getLogger(StandaloneServer.class).error("The documents4j server terminated with an unexpected error", e);
             System.err.printf("Error: %s%n", e.getMessage());
@@ -105,15 +95,13 @@ public class StandaloneServer {
         OptionSpec<?> sslSpec = makeSslSpec(optionParser);
 
         ArgumentAcceptingOptionSpec<String> authSpec = makeAuthSpec(optionParser);
-        ArgumentAcceptingOptionSpec<File> logFileSpec = makeLogFileSpec(optionParser);
         ArgumentAcceptingOptionSpec<Level> logLevelSpec = makeLogLevelSpec(optionParser);
-        OptionSpec<?> jsonSpec = makeJsonLogSpec(optionParser);
 
         OptionSet optionSet;
         try {
             optionSet = optionParser.parse(args);
         } catch (OptionException e) {
-            System.out.println("The converter was started with unknown arguments: " + e.options());
+            LOG.info("The converter was started with unknown arguments: {}", e.options());
             optionParser.printHelpOn(System.out);
             System.exit(-1);
             throw e; // To satisfy the Java compiler.
@@ -126,7 +114,7 @@ public class StandaloneServer {
 
         URI baseUri = baseUriSpec.value(optionSet);
         if (baseUri == null) {
-            System.out.println("No base URI parameter specified. (Use: <command> <base URI>)");
+            LOG.info("No base URI parameter specified. (Use: <command> <base URI>)");
             System.exit(-1);
         }
 
@@ -146,16 +134,8 @@ public class StandaloneServer {
         long requestTimeout = requestTimeoutSpec.value(optionSet);
         checkArgument(requestTimeout >= 0L, "The request timeout timeout must not be negative");
 
-        File logFile = logFileSpec.value(optionSet);
-
         Level level = logLevelSpec.value(optionSet);
-        System.out.println("Logging: The log level is set to " + level);
-
-        if (optionSet.has(jsonSpec)) {
-            configureJsonLogging(level);
-        } else {
-            configureRegularLogging(logFile, level);
-        }
+        LOG.info("Logging: The log level is set to " + level);
 
         ConverterServerBuilder builder = ConverterServerBuilder.builder()
                 .baseUri(baseUri)
@@ -173,7 +153,7 @@ public class StandaloneServer {
             try {
                 builder = builder.sslContext(SSLContext.getDefault());
             } catch (NoSuchAlgorithmException e) {
-                System.out.println("Could not access default SSL context: " + e.getMessage());
+                LOG.info("Could not access default SSL context: " + e.getMessage());
                 System.exit(-1);
             }
         }
@@ -183,151 +163,11 @@ public class StandaloneServer {
         return builder.serviceMode(serviceMode);
     }
 
-    private static void configureRegularLogging(File logFile, Level level) {
-        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        OutputStreamAppender<ILoggingEvent> appender;
-        if (logFile == null) {
-            appender = configureConsoleLogging(loggerContext);
-        } else {
-            appender = configureFileLogging(logFile, loggerContext);
-        }
-
-        PatternLayoutEncoder patternLayoutEncoder = new PatternLayoutEncoder();
-        patternLayoutEncoder.setPattern(LogDescription.LOG_PATTERN);
-        patternLayoutEncoder.setContext(loggerContext);
-        patternLayoutEncoder.start();
-        appender.setEncoder(patternLayoutEncoder);
-        appender.start();
-        ch.qos.logback.classic.Logger rootLogger = loggerContext.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
-        loggerContext.stop();
-        rootLogger.detachAndStopAllAppenders();
-        rootLogger.addAppender(appender);
-        rootLogger.setLevel(level);
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
-        LevelChangePropagator levelChangePropagator = new LevelChangePropagator();
-        levelChangePropagator.setResetJUL(true);
-        levelChangePropagator.setContext(loggerContext);
-        levelChangePropagator.start();
-        loggerContext.addListener(levelChangePropagator);
-        loggerContext.start();
-    }
-
-    private static OutputStreamAppender<ILoggingEvent> configureConsoleLogging(LoggerContext loggerContext) {
-        ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();
-        consoleAppender.setName("com.documents4j.logger.server.console");
-        consoleAppender.setContext(loggerContext);
-        System.out.println("Logging: The log is printed to the console as patterns");
-        return consoleAppender;
-    }
-
-    private static OutputStreamAppender<ILoggingEvent> configureFileLogging(File logFile, LoggerContext loggerContext) {
-        RollingFileAppender<ILoggingEvent> rollingFileAppender = new RollingFileAppender<ILoggingEvent>();
-        rollingFileAppender.setFile(logFile.getAbsolutePath());
-        rollingFileAppender.setName("com.documents4j.logger.server.file");
-        rollingFileAppender.setContext(loggerContext);
-        FixedWindowRollingPolicy fixedWindowRollingPolicy = new FixedWindowRollingPolicy();
-        fixedWindowRollingPolicy.setFileNamePattern(logFile.getAbsolutePath() + ".%i.gz");
-        fixedWindowRollingPolicy.setMaxIndex(LogDescription.MAXIMUM_LOG_HISTORY_INDEX);
-        fixedWindowRollingPolicy.setContext(loggerContext);
-        fixedWindowRollingPolicy.setParent(rollingFileAppender);
-        SizeBasedTriggeringPolicy<ILoggingEvent> sizeBasedTriggeringPolicy = new SizeBasedTriggeringPolicy<ILoggingEvent>();
-        sizeBasedTriggeringPolicy.setMaxFileSize(FileSize.valueOf(LogDescription.MAXIMUM_LOG_FILE_SIZE));
-        sizeBasedTriggeringPolicy.setContext(loggerContext);
-        rollingFileAppender.setRollingPolicy(fixedWindowRollingPolicy);
-        rollingFileAppender.setTriggeringPolicy(sizeBasedTriggeringPolicy);
-        sizeBasedTriggeringPolicy.start();
-        fixedWindowRollingPolicy.start();
-        System.out.println("Logging: The log is written to " + logFile);
-        return rollingFileAppender;
-    }
-
-    private static void configureJsonLogging(Level rootLogLevel) {
-        System.out.println("Logging: The log is printed to the console as JSON");
-        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        OutputStreamAppender<ILoggingEvent> appender = configureConsoleLogging(loggerContext);
-
-        LoggingEventCompositeJsonEncoder jsonEncoder = configureJsonEncoder(loggerContext);
-        jsonEncoder.start();
-
-        appender.setEncoder(jsonEncoder);
-        appender.start();
-
-        ch.qos.logback.classic.Logger rootLogger = loggerContext.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
-        loggerContext.stop();
-        rootLogger.detachAndStopAllAppenders();
-        rootLogger.addAppender(appender);
-        rootLogger.setLevel(rootLogLevel);
-
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
-
-        LevelChangePropagator levelChangePropagator = new LevelChangePropagator();
-        levelChangePropagator.setResetJUL(true);
-        levelChangePropagator.setContext(loggerContext);
-        levelChangePropagator.start();
-        loggerContext.addListener(levelChangePropagator);
-
-        loggerContext.start();
-    }
-
-    private static LoggingEventCompositeJsonEncoder configureJsonEncoder(Context context) {
-        LoggingEventFormattedTimestampJsonProvider timestamp = new LoggingEventFormattedTimestampJsonProvider();
-        timestamp.setFieldName("time");
-        timestamp.setPattern("[UNIX_TIMESTAMP_AS_NUMBER]");
-
-        LoggingEventPatternJsonProvider level = new LoggingEventPatternJsonProvider();
-        level.setPattern("{\n\"level\": \"%level\"\n}");
-
-        MessageJsonProvider message = new MessageJsonProvider();
-        message.setFieldName("msg");
-
-        LoggerNameJsonProvider loggerName = new LoggerNameJsonProvider();
-        loggerName.setFieldName("logger");
-
-        CallerDataJsonProvider callerData = new CallerDataJsonProvider();
-        callerData.setClassFieldName("class");
-        callerData.setMethodFieldName("method");
-        callerData.setLineFieldName("line");
-        callerData.setFileFieldName("file");
-
-        LoggingEventThreadNameJsonProvider threadName = new LoggingEventThreadNameJsonProvider();
-        threadName.setFieldName("thread");
-
-        MdcJsonProvider mdc = new MdcJsonProvider();
-
-        ArgumentsJsonProvider arguments = new ArgumentsJsonProvider();
-        arguments.setIncludeNonStructuredArguments(false);
-
-        StackTraceJsonProvider stackTrace = new StackTraceJsonProvider();
-        stackTrace.setFieldName("error.stack");
-
-        KeyValuePairsJsonProvider keyValuePairs = new KeyValuePairsJsonProvider();
-
-        LoggingEventJsonProviders providers = new LoggingEventJsonProviders();
-        providers.addTimestamp(timestamp);
-        providers.addProvider(level);
-        providers.addMessage(message);
-        providers.addLoggerName(loggerName);
-        providers.addCallerData(callerData);
-        providers.addThreadName(threadName);
-        providers.addMdc(mdc);
-        providers.addArguments(arguments);
-        providers.addStackTrace(stackTrace);
-        providers.addKeyValuePairs(keyValuePairs);
-
-        LoggingEventCompositeJsonEncoder jsonEncoder = new LoggingEventCompositeJsonEncoder();
-        jsonEncoder.setProviders(providers);
-        jsonEncoder.setContext(context);
-
-        return jsonEncoder;
-    }
-
     private static ArgumentAcceptingOptionSpec<File> makeBaseFolderSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_BASE_FOLDER,
-                        CommandDescription.ARGUMENT_SHORT_BASE_FOLDER),
+                                CommandDescription.ARGUMENT_LONG_BASE_FOLDER,
+                                CommandDescription.ARGUMENT_SHORT_BASE_FOLDER),
                         CommandDescription.DESCRIPTION_CONTEXT_BASE_FOLDER
                 )
                 .withRequiredArg()
@@ -339,8 +179,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Integer> makeCorePoolSizeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_CORE_POOL_SIZE,
-                        CommandDescription.ARGUMENT_SHORT_CORE_POOL_SIZE),
+                                CommandDescription.ARGUMENT_LONG_CORE_POOL_SIZE,
+                                CommandDescription.ARGUMENT_SHORT_CORE_POOL_SIZE),
                         CommandDescription.DESCRIPTION_CONTEXT_CORE_POOL_SIZE
                 )
                 .withRequiredArg()
@@ -352,8 +192,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Integer> makeFallbackPoolSizeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_MAXIMUM_POOL_SIZE,
-                        CommandDescription.ARGUMENT_SHORT_MAXIMUM_POOL_SIZE),
+                                CommandDescription.ARGUMENT_LONG_MAXIMUM_POOL_SIZE,
+                                CommandDescription.ARGUMENT_SHORT_MAXIMUM_POOL_SIZE),
                         CommandDescription.DESCRIPTION_CONTEXT_MAXIMUM_POOL_SIZE
                 )
                 .withRequiredArg()
@@ -365,8 +205,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Long> makeKeepAliveTimeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_KEEP_ALIVE_TIME,
-                        CommandDescription.ARGUMENT_SHORT_KEEP_ALIVE_TIME),
+                                CommandDescription.ARGUMENT_LONG_KEEP_ALIVE_TIME,
+                                CommandDescription.ARGUMENT_SHORT_KEEP_ALIVE_TIME),
                         CommandDescription.DESCRIPTION_CONTEXT_KEEP_ALIVE_TIME
                 )
                 .withRequiredArg()
@@ -378,8 +218,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Long> makeProcessTimeoutSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_PROCESS_TIME_OUT,
-                        CommandDescription.ARGUMENT_SHORT_PROCESS_TIME_OUT),
+                                CommandDescription.ARGUMENT_LONG_PROCESS_TIME_OUT,
+                                CommandDescription.ARGUMENT_SHORT_PROCESS_TIME_OUT),
                         CommandDescription.DESCRIPTION_CONTEXT_PROCESS_TIME_OUT
                 )
                 .withRequiredArg()
@@ -391,8 +231,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Long> makeRequestTimeoutSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_REQUEST_TIMEOUT,
-                        CommandDescription.ARGUMENT_SHORT_REQUEST_TIMEOUT),
+                                CommandDescription.ARGUMENT_LONG_REQUEST_TIMEOUT,
+                                CommandDescription.ARGUMENT_SHORT_REQUEST_TIMEOUT),
                         CommandDescription.DESCRIPTION_CONTEXT_REQUEST_TIMEOUT
                 )
                 .withRequiredArg()
@@ -404,8 +244,8 @@ public class StandaloneServer {
     private static OptionSpec<?> makeSslSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_SSL,
-                        CommandDescription.ARGUMENT_SHORT_SSL),
+                                CommandDescription.ARGUMENT_LONG_SSL,
+                                CommandDescription.ARGUMENT_SHORT_SSL),
                         CommandDescription.DESCRIPTION_CONTEXT_SSL
                 );
     }
@@ -413,31 +253,18 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<String> makeAuthSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_AUTH,
-                        CommandDescription.ARGUMENT_SHORT_AUTH),
+                                CommandDescription.ARGUMENT_LONG_AUTH,
+                                CommandDescription.ARGUMENT_SHORT_AUTH),
                         CommandDescription.DESCRIPTION_CONTEXT_AUTH
                 ).withRequiredArg()
                 .ofType(String.class);
     }
 
-    private static ArgumentAcceptingOptionSpec<File> makeLogFileSpec(OptionParser optionParser) {
-        return optionParser
-                .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_LOG_TO_FILE,
-                        CommandDescription.ARGUMENT_SHORT_LOG_TO_FILE),
-                        CommandDescription.DESCRIPTION_CONTEXT_LOG_TO_FILE
-                )
-                .withRequiredArg()
-                .describedAs(CommandDescription.DESCRIPTION_ARGUMENT_LOG_TO_FILE)
-                .ofType(File.class);
-        // defaults to null such that all log information is written to the console
-    }
-
     private static ArgumentAcceptingOptionSpec<Level> makeLogLevelSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_LOG_LEVEL,
-                        CommandDescription.ARGUMENT_SHORT_LOG_LEVEL),
+                                CommandDescription.ARGUMENT_LONG_LOG_LEVEL,
+                                CommandDescription.ARGUMENT_SHORT_LOG_LEVEL),
                         CommandDescription.DESCRIPTION_CONTEXT_LOG_LEVEL
                 )
                 .withRequiredArg()
@@ -446,20 +273,11 @@ public class StandaloneServer {
                 .defaultsTo(Level.WARN);
     }
 
-    private static OptionSpec<?> makeJsonLogSpec(OptionParser optionParser) {
-        return optionParser
-                .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_JSON_LOG,
-                        CommandDescription.ARGUMENT_SHORT_JSON_LOG),
-                        CommandDescription.DESCRIPTION_ARGUMENT_JSON_LOG
-                );
-    }
-
     private static ArgumentAcceptingOptionSpec<Class<? extends IExternalConverter>> makeConverterDisabledSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_DISABLED_CONVERTER,
-                        CommandDescription.ARGUMENT_SHORT_DISABLED_CONVERTER),
+                                CommandDescription.ARGUMENT_LONG_DISABLED_CONVERTER,
+                                CommandDescription.ARGUMENT_SHORT_DISABLED_CONVERTER),
                         CommandDescription.DESCRIPTION_CONTEXT_DISABLED_CONVERTER
                 )
                 .withRequiredArg()
@@ -470,8 +288,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Class<? extends IExternalConverter>> makeConverterEnabledSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_ENABLED_CONVERTER,
-                        CommandDescription.ARGUMENT_SHORT_ENABLED_CONVERTER),
+                                CommandDescription.ARGUMENT_LONG_ENABLED_CONVERTER,
+                                CommandDescription.ARGUMENT_SHORT_ENABLED_CONVERTER),
                         CommandDescription.DESCRIPTION_CONTEXT_ENABLED_CONVERTER
                 )
                 .withRequiredArg()
@@ -486,8 +304,8 @@ public class StandaloneServer {
     private static OptionSpec<Void> makeHelpSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_HELP,
-                        CommandDescription.ARGUMENT_SHORT_HELP),
+                                CommandDescription.ARGUMENT_LONG_HELP,
+                                CommandDescription.ARGUMENT_SHORT_HELP),
                         CommandDescription.DESCRIPTION_CONTEXT_HELP
                 )
                 .forHelp();
@@ -496,33 +314,33 @@ public class StandaloneServer {
     private static OptionSpec<Void> makeServiceModeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                        CommandDescription.ARGUMENT_LONG_SERVICE_MODE,
-                        CommandDescription.ARGUMENT_SHORT_SERVICE_MODE),
+                                CommandDescription.ARGUMENT_LONG_SERVICE_MODE,
+                                CommandDescription.ARGUMENT_SHORT_SERVICE_MODE),
                         CommandDescription.DESCRIPTION_CONTEXT_SERVICE_MODE
                 );
     }
 
-    private static void sayHello(ConverterServerBuilder builder, Logger logger) {
-        System.out.println("Welcome to the documents4j server!");
+    private static void sayHello(ConverterServerBuilder builder) {
+        LOG.info("Welcome to the documents4j server!");
         String serverStartupMessage = String.format("%tc: Started server on '%s'", System.currentTimeMillis(), builder.getBaseUri());
-        logger.info(serverStartupMessage);
-        logServerInfo(builder, logger);
-        System.out.println(serverStartupMessage);
+        LOG.info(serverStartupMessage);
+        logServerInfo(builder);
+        LOG.info(serverStartupMessage);
     }
 
-    private static void logServerInfo(ConverterServerBuilder builder, Logger logger) {
-        logger.info("documents4j server is listening at {}", builder.getBaseUri());
-        logger.info("documents4j server is writing temporary files to: {}",
+    private static void logServerInfo(ConverterServerBuilder builder) {
+        LOG.info("documents4j server is listening at {}", builder.getBaseUri());
+        LOG.info("documents4j server is writing temporary files to: {}",
                 builder.getBaseFolder() == null ? "<temporary folder>" : builder.getBaseFolder());
-        logger.info("documents4j server worker threads: {} (+{}) - timeout: {} ms",
+        LOG.info("documents4j server worker threads: {} (+{}) - timeout: {} ms",
                 builder.getCorePoolSize(), builder.getMaximumPoolSize(), builder.getKeepAliveTime());
-        logger.info("documents4j server process timeout: {}", builder.getProcessTimeout());
-        logger.info("documents4j server request timeout: {}", builder.getRequestTimeout());
+        LOG.info("documents4j server process timeout: {}", builder.getProcessTimeout());
+        LOG.info("documents4j server request timeout: {}", builder.getRequestTimeout());
     }
 
-    private static void sayGoodbye(ConverterServerBuilder builder, Logger logger) {
+    private static void sayGoodbye(ConverterServerBuilder builder) {
         String serverShutdownMessage = String.format("%tc: Shutting down server on '%s'", System.currentTimeMillis(), builder.getBaseUri());
-        logger.info(serverShutdownMessage);
-        System.out.println(serverShutdownMessage);
+        LOG.info(serverShutdownMessage);
+        LOG.info(serverShutdownMessage);
     }
 }

--- a/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
+++ b/documents4j-server-standalone/src/main/java/com/documents4j/standalone/StandaloneServer.java
@@ -166,8 +166,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<File> makeBaseFolderSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_BASE_FOLDER,
-                                CommandDescription.ARGUMENT_SHORT_BASE_FOLDER),
+                        CommandDescription.ARGUMENT_LONG_BASE_FOLDER,
+                        CommandDescription.ARGUMENT_SHORT_BASE_FOLDER),
                         CommandDescription.DESCRIPTION_CONTEXT_BASE_FOLDER
                 )
                 .withRequiredArg()
@@ -179,8 +179,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Integer> makeCorePoolSizeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_CORE_POOL_SIZE,
-                                CommandDescription.ARGUMENT_SHORT_CORE_POOL_SIZE),
+                        CommandDescription.ARGUMENT_LONG_CORE_POOL_SIZE,
+                        CommandDescription.ARGUMENT_SHORT_CORE_POOL_SIZE),
                         CommandDescription.DESCRIPTION_CONTEXT_CORE_POOL_SIZE
                 )
                 .withRequiredArg()
@@ -192,8 +192,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Integer> makeFallbackPoolSizeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_MAXIMUM_POOL_SIZE,
-                                CommandDescription.ARGUMENT_SHORT_MAXIMUM_POOL_SIZE),
+                        CommandDescription.ARGUMENT_LONG_MAXIMUM_POOL_SIZE,
+                        CommandDescription.ARGUMENT_SHORT_MAXIMUM_POOL_SIZE),
                         CommandDescription.DESCRIPTION_CONTEXT_MAXIMUM_POOL_SIZE
                 )
                 .withRequiredArg()
@@ -205,8 +205,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Long> makeKeepAliveTimeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_KEEP_ALIVE_TIME,
-                                CommandDescription.ARGUMENT_SHORT_KEEP_ALIVE_TIME),
+                        CommandDescription.ARGUMENT_LONG_KEEP_ALIVE_TIME,
+                        CommandDescription.ARGUMENT_SHORT_KEEP_ALIVE_TIME),
                         CommandDescription.DESCRIPTION_CONTEXT_KEEP_ALIVE_TIME
                 )
                 .withRequiredArg()
@@ -218,8 +218,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Long> makeProcessTimeoutSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_PROCESS_TIME_OUT,
-                                CommandDescription.ARGUMENT_SHORT_PROCESS_TIME_OUT),
+                        CommandDescription.ARGUMENT_LONG_PROCESS_TIME_OUT,
+                        CommandDescription.ARGUMENT_SHORT_PROCESS_TIME_OUT),
                         CommandDescription.DESCRIPTION_CONTEXT_PROCESS_TIME_OUT
                 )
                 .withRequiredArg()
@@ -231,8 +231,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Long> makeRequestTimeoutSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_REQUEST_TIMEOUT,
-                                CommandDescription.ARGUMENT_SHORT_REQUEST_TIMEOUT),
+                        CommandDescription.ARGUMENT_LONG_REQUEST_TIMEOUT,
+                        CommandDescription.ARGUMENT_SHORT_REQUEST_TIMEOUT),
                         CommandDescription.DESCRIPTION_CONTEXT_REQUEST_TIMEOUT
                 )
                 .withRequiredArg()
@@ -244,8 +244,8 @@ public class StandaloneServer {
     private static OptionSpec<?> makeSslSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_SSL,
-                                CommandDescription.ARGUMENT_SHORT_SSL),
+                        CommandDescription.ARGUMENT_LONG_SSL,
+                        CommandDescription.ARGUMENT_SHORT_SSL),
                         CommandDescription.DESCRIPTION_CONTEXT_SSL
                 );
     }
@@ -253,8 +253,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<String> makeAuthSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_AUTH,
-                                CommandDescription.ARGUMENT_SHORT_AUTH),
+                        CommandDescription.ARGUMENT_LONG_AUTH,
+                        CommandDescription.ARGUMENT_SHORT_AUTH),
                         CommandDescription.DESCRIPTION_CONTEXT_AUTH
                 ).withRequiredArg()
                 .ofType(String.class);
@@ -263,8 +263,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Level> makeLogLevelSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_LOG_LEVEL,
-                                CommandDescription.ARGUMENT_SHORT_LOG_LEVEL),
+                        CommandDescription.ARGUMENT_LONG_LOG_LEVEL,
+                        CommandDescription.ARGUMENT_SHORT_LOG_LEVEL),
                         CommandDescription.DESCRIPTION_CONTEXT_LOG_LEVEL
                 )
                 .withRequiredArg()
@@ -276,8 +276,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Class<? extends IExternalConverter>> makeConverterDisabledSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_DISABLED_CONVERTER,
-                                CommandDescription.ARGUMENT_SHORT_DISABLED_CONVERTER),
+                        CommandDescription.ARGUMENT_LONG_DISABLED_CONVERTER,
+                        CommandDescription.ARGUMENT_SHORT_DISABLED_CONVERTER),
                         CommandDescription.DESCRIPTION_CONTEXT_DISABLED_CONVERTER
                 )
                 .withRequiredArg()
@@ -288,8 +288,8 @@ public class StandaloneServer {
     private static ArgumentAcceptingOptionSpec<Class<? extends IExternalConverter>> makeConverterEnabledSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_ENABLED_CONVERTER,
-                                CommandDescription.ARGUMENT_SHORT_ENABLED_CONVERTER),
+                        CommandDescription.ARGUMENT_LONG_ENABLED_CONVERTER,
+                        CommandDescription.ARGUMENT_SHORT_ENABLED_CONVERTER),
                         CommandDescription.DESCRIPTION_CONTEXT_ENABLED_CONVERTER
                 )
                 .withRequiredArg()
@@ -304,8 +304,8 @@ public class StandaloneServer {
     private static OptionSpec<Void> makeHelpSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_HELP,
-                                CommandDescription.ARGUMENT_SHORT_HELP),
+                        CommandDescription.ARGUMENT_LONG_HELP,
+                        CommandDescription.ARGUMENT_SHORT_HELP),
                         CommandDescription.DESCRIPTION_CONTEXT_HELP
                 )
                 .forHelp();
@@ -314,8 +314,8 @@ public class StandaloneServer {
     private static OptionSpec<Void> makeServiceModeSpec(OptionParser optionParser) {
         return optionParser
                 .acceptsAll(Arrays.asList(
-                                CommandDescription.ARGUMENT_LONG_SERVICE_MODE,
-                                CommandDescription.ARGUMENT_SHORT_SERVICE_MODE),
+                        CommandDescription.ARGUMENT_LONG_SERVICE_MODE,
+                        CommandDescription.ARGUMENT_SHORT_SERVICE_MODE),
                         CommandDescription.DESCRIPTION_CONTEXT_SERVICE_MODE
                 );
     }

--- a/documents4j-util-standalone/src/main/java/com/documents4j/standalone/CommandDescription.java
+++ b/documents4j-util-standalone/src/main/java/com/documents4j/standalone/CommandDescription.java
@@ -77,6 +77,11 @@ public class CommandDescription {
             "by the converter. Valid log levels are 'off', 'error', 'warn', 'info', 'debug' and 'trace'. Without explicit configuration, " +
             "the 'warn' level is activated which is also the recommended level for production use of the converter.";
 
+    public static final String ARGUMENT_LONG_JSON_LOG = "json-log";
+    public static final String ARGUMENT_SHORT_JSON_LOG = "J";
+    public static final String DESCRIPTION_ARGUMENT_JSON_LOG = "External log aggregator services often require log output " +
+            "to be JSON. This allows for easier parsing of exception stack traces.";
+
     public static final String ARGUMENT_LONG_ENABLED_CONVERTER = "enable";
     public static final String ARGUMENT_SHORT_ENABLED_CONVERTER = "E";
     public static final String DESCRIPTION_ARGUMENT_ENABLED_CONVERTER = "The fully qualified Java class name of the document converter to enable.";

--- a/pom.xml
+++ b/pom.xml
@@ -91,26 +91,27 @@
         <version.guava>30.0-jre</version.guava>
         <version.zt-exec>1.11</version.zt-exec>
         <version.jopt-simple>5.0.4</version.jopt-simple>
-        <version.slf4j>1.7.28</version.slf4j>
-        <version.logback>1.2.3</version.logback>
+        <version.slf4j>2.0.13</version.slf4j>
+        <version.logback>1.5.6</version.logback>
         <version.junit>4.13.1</version.junit>
         <version.mockito>3.0.0</version.mockito>
         <version.thread-weaver>0.2</version.thread-weaver>
         <version.jetty>9.4.20.v20190813</version.jetty>
-        <version.maven.compiler-plugin>3.11.0</version.maven.compiler-plugin>
-        <version.maven.surefire-plugin>2.16</version.maven.surefire-plugin>
-        <version.maven.source-plugin>3.3.0</version.maven.source-plugin>
-        <version.maven.javadoc-plugin>3.5.0</version.maven.javadoc-plugin>
-        <version.maven.gpg-plugin>1.6</version.maven.gpg-plugin>
-        <version.maven.war-plugin>2.3</version.maven.war-plugin>
-        <version.maven.shade-plugin>2.1</version.maven.shade-plugin>
+        <version.logstash.encoder>7.4</version.logstash.encoder>
+        <version.maven.compiler-plugin>3.13.0</version.maven.compiler-plugin>
+        <version.maven.surefire-plugin>3.2.5</version.maven.surefire-plugin>
+        <version.maven.source-plugin>3.3.1</version.maven.source-plugin>
+        <version.maven.javadoc-plugin>3.7.0</version.maven.javadoc-plugin>
+        <version.maven.gpg-plugin>3.2.4</version.maven.gpg-plugin>
+        <version.maven.war-plugin>3.4.0</version.maven.war-plugin>
+        <version.maven.shade-plugin>3.6.0</version.maven.shade-plugin>
         <version.maven.cobertura-plugin>2.7</version.maven.cobertura-plugin>
         <version.maven.checkstyle-plugin>2.15</version.maven.checkstyle-plugin>
-        <version.maven.resources-plugin>2.6</version.maven.resources-plugin>
-        <version.maven.release-plugin>2.5.1</version.maven.release-plugin>
-        <version.maven.install-plugin>2.5.1</version.maven.install-plugin>
-        <version.maven.jxr-plugin>2.3</version.maven.jxr-plugin>
-        <version.java>8</version.java>
+        <version.maven.resources-plugin>3.3.1</version.maven.resources-plugin>
+        <version.maven.release-plugin>3.0.1</version.maven.release-plugin>
+        <version.maven.install-plugin>3.1.2</version.maven.install-plugin>
+        <version.maven.jxr-plugin>3.4.0</version.maven.jxr-plugin>
+        <version.java>11</version.java>
     </properties>
 
     <developers>
@@ -257,6 +258,12 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${version.logback}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.logstash.logback</groupId>
+                <artifactId>logstash-logback-encoder</artifactId>
+                <version>${version.logstash.encoder}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <version.javax.servlet>3.0.1</version.javax.servlet>
         <version.jakarta.inject>2.0.0</version.jakarta.inject>
         <version.jakarta.bind>3.0.0</version.jakarta.bind>
-        <version.glashfish.jaxb>3.0.2</version.glashfish.jaxb>
+        <version.glassfish.jaxb>3.0.2</version.glassfish.jaxb>
         <version.jersey>3.0.2</version.jersey>
         <version.guava>30.0-jre</version.guava>
         <version.zt-exec>1.11</version.zt-exec>
@@ -238,7 +238,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>${version.glashfish.jaxb}</version>
+                <version>${version.glassfish.jaxb}</version>
             </dependency>
 
             <!-- Testing / Logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -261,12 +261,6 @@
             </dependency>
 
             <dependency>
-                <groupId>net.logstash.logback</groupId>
-                <artifactId>logstash-logback-encoder</artifactId>
-                <version>${version.logstash.encoder}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jul-to-slf4j</artifactId>
                 <version>${version.slf4j}</version>


### PR DESCRIPTION
Hi @raphw,

thanks for maintaining this project. We're consuming our logs using Datadog, a cloud based log aggregator and monitoring tool. It's much easier for those systems to consume log events when they're in machine readable format, so I've added an option to switch the log output to JSON hoping this might be handy for other people as well.

**Details:**
- activated using -J or --json-log
- uses Logstash's LoggingEventCompositeJsonEncoder
- required to up the Java Version to 11
- also updated Maven Plugins where possible
- also updates slf4j to 2.x

**More notes:**
I haven't been able to run all the tests on my machine (macOS) because of issues writing to the temporary directory.

In a spike I've managed to get one to work again using JUnit 5 and `@TempDir`. That also neatly got rid of some manual cleanup that the test was doing. I haven't added that to this PR because it would have conflated too many things.

However, I had to update Java to 11 in order to get the JSON log library to run (Logstash).

**Other considerations:**
I would love to have the option to let the user provide their own log configuration using either a `logback.xml` or even provide their own library at deploy time. The former seems like the next pragmatic thing to do. The latter is probably how they intended slf4j to be used.